### PR TITLE
feat: harmony bridger + kickstart script

### DIFF
--- a/contracts/bridgers/HarmonyBridger.vy
+++ b/contracts/bridgers/HarmonyBridger.vy
@@ -1,0 +1,59 @@
+# @version 0.3.1
+"""
+@notice Curve Harmony Bridge Wrapper
+"""
+from vyper.interfaces import ERC20
+
+
+interface HarmonyBridge:
+    def lockToken(_token: address, _amount: uint256, _receiver: address): nonpayable
+
+
+CRV20: constant(address) = 0xD533a949740bb3306d119CC777fa900bA034cd52
+HARMONY_BRIDGE: constant(address) = 0x2dCCDB493827E15a5dC8f8b72147E6c4A5620857
+
+
+# token -> is approval given to bridge
+is_approved: public(HashMap[address, bool])
+
+
+@external
+def __init__():
+    assert ERC20(CRV20).approve(HARMONY_BRIDGE, MAX_UINT256)
+    self.is_approved[CRV20] = True
+
+
+@external
+def bridge(_token: address, _to: address, _amount: uint256):
+    """
+    @notice Bridge a token to Harmony mainnet
+    @param _token The token to bridge
+    @param _to The address to deposit the token to on harmony
+    @param _amount The amount of the token to bridge
+    """
+    assert ERC20(_token).transferFrom(msg.sender, self, _amount)
+
+    if _token != CRV20 and not self.is_approved[_token]:
+        assert ERC20(_token).approve(HARMONY_BRIDGE, MAX_UINT256)
+        self.is_approved[_token] = True
+
+    HarmonyBridge(HARMONY_BRIDGE).lockToken(_token, _amount, _to)
+
+
+@pure
+@external
+def cost() -> uint256:
+    """
+    @notice Cost in ETH to bridge
+    """
+    return 0
+
+
+@pure
+@external
+def check(_account: address) -> bool:
+    """
+    @notice Check if `_account` is allowed to bridge
+    @param _account The account to check
+    """
+    return True

--- a/scripts/check_emissions.py
+++ b/scripts/check_emissions.py
@@ -53,7 +53,7 @@ def main():
             gauges_to_emit.append(gauge_addr)
         except Exception:
             pass
-    if len(gauges_to_emit != 0):
+    if len(gauges_to_emit) != 0:
         print(gauges_to_emit)
     else:
         print("No gauges require a kickstart")

--- a/scripts/check_emissions.py
+++ b/scripts/check_emissions.py
@@ -21,6 +21,8 @@ NETWORK_IDS = [
     1666600000,  # harmony
 ]
 
+dev = accounts.load("dev")
+
 
 def main():
     factory = RootGaugeFactory.at("0xabC000d88f23Bb45525E447528DBF656A9D55bf5")
@@ -49,11 +51,11 @@ def main():
     gauges_to_emit = []
     for gauge_addr in transmission_set:
         try:
-            factory.transmit_emissions(gauge_addr, {"from": accounts[0], "allow_revert": True})
-            gauges_to_emit.append(gauge_addr)
+            factory.transmit_emissions.call(gauge_addr)
+            factory.transmit_emissions(gauge_addr, {"from": dev, "priority_fee": "2 gwei"})
         except Exception:
             pass
     if len(gauges_to_emit) != 0:
         print(gauges_to_emit)
     else:
-        print("No gauges require a kickstart")
+        print("No gauges required a kickstart")

--- a/scripts/check_emissions.py
+++ b/scripts/check_emissions.py
@@ -1,0 +1,59 @@
+"""
+Thanks to the anycall integration the gauge system is 99% automatic when it comes to CRV emissions.
+However, for new gauges, they require a kickstart for the first time emissions are to be bridged.
+This is due to the fact that future emissions will automatically be bridged as users mint on
+the child chain. But when a gauge first begins ... no users will call mint, since there
+is nothing to mint.
+"""
+from inspect import unwrap
+from itertools import compress
+
+import brownie
+from brownie import Contract, RootGauge, RootGaugeFactory, accounts
+
+NETWORK_IDS = [
+    10,  # optimism
+    100,  # xdai
+    137,  # polygon
+    250,  # ftm
+    42161,  # arbitrum
+    43114,  # avax
+    1666600000,  # harmony
+]
+
+
+def main():
+    factory = RootGaugeFactory.at("0xabC000d88f23Bb45525E447528DBF656A9D55bf5")
+    gauge_controller = Contract("0x2F50D538606Fa9EDD2B11E2446BEb18C9D5846bB")  # gauge controller
+
+    with brownie.multicall:
+        # fetch all the gauges for each network in NETWORK_IDS
+        gauges = [
+            factory.get_gauge(chain_id, i)
+            for chain_id in NETWORK_IDS
+            for i in range(factory.get_gauge_count(chain_id))
+        ]
+        # fetch each gauges gauge_type, gauges not voted in have no gauge_type
+        gauge_types = [gauge_controller.gauge_types(gauge) for gauge in gauges]
+
+        # filter gauges that have been voted in by the Curve DAO
+        valid_gauges = list(compress(gauges, map(lambda t: unwrap(t) is not None, gauge_types)))
+
+        # we want all the gauges with 0 as total_emissions because these are new
+        gauge_emissions = [
+            RootGauge.at(gauge_addr).total_emissions() for gauge_addr in valid_gauges
+        ]
+        # filter gauges that haven't emitted any CRV
+        transmission_set = list(compress(valid_gauges, map(lambda e: e == 0, gauge_emissions)))
+
+    gauges_to_emit = []
+    for gauge_addr in transmission_set:
+        try:
+            factory.transmit_emissions(gauge_addr, {"from": accounts[0], "allow_revert": True})
+            gauges_to_emit.append(gauge_addr)
+        except Exception:
+            pass
+    if len(gauges_to_emit != 0):
+        print(gauges_to_emit)
+    else:
+        print("No gauges require a kickstart")

--- a/tests/forked/test_bridgers.py
+++ b/tests/forked/test_bridgers.py
@@ -116,3 +116,20 @@ def test_polygon_bridger(alice, crv_token, PolygonBridger):
     assert "LockedERC20" in tx.events
     assert tx.events["LockedERC20"]["rootToken"] == crv_token
     assert tx.events["LockedERC20"]["amount"] == 10 ** 18
+
+
+def test_harmony_bridger(alice, crv_token, HarmonyBridger):
+    harmony_bridge = "0x2dCCDB493827E15a5dC8f8b72147E6c4A5620857"
+    bridger = HarmonyBridger.deploy({"from": alice})
+
+    assert bridger.cost() == 0
+    assert bridger.check(alice) is True
+
+    crv_token.approve(bridger, 2 ** 256 - 1, {"from": alice})
+
+    balance_before = crv_token.balanceOf(harmony_bridge)
+    tx = bridger.bridge(crv_token, alice, 10 ** 18, {"from": alice})
+
+    assert crv_token.balanceOf(harmony_bridge) == balance_before + 10 ** 18
+    assert "Locked" in tx.events
+    assert tx.events["Locked"].values() == [crv_token, bridger, 10 ** 18, alice]


### PR DESCRIPTION
- Harmony bridge wrapper + test verifying it works
- Kick start script for new root gauges

The kick start script is required because there is a chicken and egg problem, emissions being bridged require some interaction. When the system is up and running this happens at maximum once a week when a user mints their CRV on the sidechain, however before a gauge receives it's first batch of emissoins, users will not call claim. Therefore, a call to push emissions the first time is required. Afterwards, any interaction with the gauge will initiate the reward accrual process.

tl;dr - run the script once a week after the epoch (anyone can run it), it'll cause new gauges with emissions to have their emissions bridged