### PR TITLE
Add child/root gauge address derivation

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ additionally emissions will be automatically bridge when requested on the altern
 ### Dependencies
 
 * [python3](https://www.python.org/downloads/release/python-368/) version 3.6 or greater, python3-dev
-* [brownie](https://github.com/eth-brownie/brownie) - tested with version [1.15.0](https://github.com/eth-brownie/brownie/releases/tag/v1.17.2)
+* [brownie](https://github.com/eth-brownie/brownie) - tested with version [1.20.6](https://github.com/eth-brownie/brownie/releases/tag/v1.17.2)
 * [ganache-cli](https://github.com/trufflesuite/ganache-cli) - tested with version [6.12.1](https://github.com/trufflesuite/ganache-cli/releases/tag/v6.12.1)
 
 ### Testing

--- a/contracts/ChildGaugeFactory.vy
+++ b/contracts/ChildGaugeFactory.vy
@@ -5,6 +5,10 @@
 @author Curve Finance
 """
 
+version: public(constant(String[8])) = "2.0.0"
+
+
+from vyper.interfaces import ERC20
 
 interface ChildGauge:
     def initialize(_lp_token: address, _root: address, _manager: address): nonpayable
@@ -53,7 +57,7 @@ event TransferOwnership:
 WEEK: constant(uint256) = 86400 * 7
 
 
-CRV: immutable(address)
+crv: public(ERC20)
 
 
 get_implementation: public(address)
@@ -77,7 +81,14 @@ get_gauge: public(address[max_value(int128)])
 
 @external
 def __init__(_call_proxy: address, _root_factory: address, _root_impl: address, _crv: address, _owner: address):
-    CRV = _crv
+    """
+    @param _call_proxy Contract for
+    @param _root_factory Root factory to anchor to
+    @param _root_impl Address of root gauge implementation to calculate mirror (can be updated)
+    @param _crv Bridged CRV token address (might be zero if not known yet)
+    @param _owner Owner of factory (xgov)
+    """
+    self.crv = ERC20(_crv)
 
     self.call_proxy = _call_proxy
     log UpdateCallProxy(empty(address), _call_proxy)
@@ -111,15 +122,8 @@ def _psuedo_mint(_gauge: address, _user: address):
     total_mint: uint256 = ChildGauge(_gauge).integrate_fraction(_user)
     to_mint: uint256 = total_mint - self.minted[_user][_gauge]
 
-    if to_mint != 0:
-        # transfer tokens to user
-        response: Bytes[32] = raw_call(
-            CRV,
-            _abi_encode(_user, to_mint, method_id=method_id("transfer(address,uint256)")),
-            max_outsize=32,
-        )
-        if len(response) != 0:
-            assert convert(response, bool)
+    if to_mint != 0 and self.crv != empty(ERC20):
+        assert self.crv.transfer(_user, to_mint, default_return_value=True)
         self.minted[_user][_gauge] = total_mint
 
         log Minted(_user, _gauge, total_mint)
@@ -185,14 +189,37 @@ def deploy_gauge(_lp_token: address, _salt: bytes32, _manager: address = msg.sen
     self.get_gauge_count = idx + 1
     self.get_gauge_from_lp_token[_lp_token] = gauge
 
-    gauge_codehash: bytes32 = keccak256(concat(0x602d3d8160093d39f3363d3d373d3d3d363d73, self.root_implementation, 0x5af43d82803e903d91602b57fd5bf3))
+    # derive root gauge address
+    gauge_codehash: bytes32 = keccak256(
+        concat(
+            0x602d3d8160093d39f3363d3d373d3d3d363d73,
+            self.root_implementation,
+            0x5af43d82803e903d91602b57fd5bf3,
+        )
+    )
     digest: bytes32 = keccak256(concat(0xFF, convert(self.root_factory, bytes20), salt, gauge_codehash))
     root: address = convert(convert(digest, uint256) & convert(max_value(uint160), uint256), address)
 
+    # If root is uninitialized, self.owner can always set the root gauge manually
+    # on the gauge contract itself via set_root_gauge method
     ChildGauge(gauge).initialize(_lp_token, root, _manager)
 
     log DeployedGauge(implementation, _lp_token, msg.sender, _salt, gauge)
     return gauge
+
+
+@external
+def set_crv(_crv: ERC20):
+    """
+    @notice Sets CRV token address
+    @dev Child gauges reference the factory to fetch CRV address
+         If empty, the gauges do not mint any CRV tokens.
+    @param _crv address of CRV token on child chain
+    """
+    assert msg.sender == self.owner
+    assert _crv != empty(ERC20)
+
+    self.crv = _crv
 
 
 @external

--- a/contracts/RootGaugeFactory.vy
+++ b/contracts/RootGaugeFactory.vy
@@ -1,4 +1,4 @@
-# @version 0.3.1
+# @version 0.3.7
 """
 @title Root Liquidity Gauge Factory
 @license MIT
@@ -10,8 +10,8 @@ interface Bridger:
     def check(_addr: address) -> bool: view
 
 interface RootGauge:
-    def bridger() -> address: view
-    def initialize(_bridger: address, _chain_id: uint256): nonpayable
+    def bridger() -> Bridger: view
+    def initialize(_bridger: Bridger, _chain_id: uint256, _child: address): nonpayable
     def transmit_emissions(): nonpayable
 
 interface CallProxy:
@@ -19,56 +19,59 @@ interface CallProxy:
         _to: address, _data: Bytes[1024], _fallback: address, _to_chain_id: uint256
     ): nonpayable
 
-
-event BridgerUpdated:
+event ChildUpdated:
     _chain_id: indexed(uint256)
-    _old_bridger: address
-    _new_bridger: address
+    _new_bridger: Bridger
+    _new_factory: address
+    _new_implementation: address
 
 event DeployedGauge:
     _implementation: indexed(address)
     _chain_id: indexed(uint256)
     _deployer: indexed(address)
     _salt: bytes32
-    _gauge: address
+    _gauge: RootGauge
 
 event TransferOwnership:
     _old_owner: address
     _new_owner: address
 
 event UpdateCallProxy:
-    _old_call_proxy: address
-    _new_call_proxy: address
+    _old_call_proxy: CallProxy
+    _new_call_proxy: CallProxy
 
 event UpdateImplementation:
     _old_implementation: address
     _new_implementation: address
 
 
-call_proxy: public(address)
-
-get_bridger: public(HashMap[uint256, address])
+call_proxy: public(CallProxy)
+get_bridger: public(HashMap[uint256, Bridger])
+get_child_factory: public(HashMap[uint256, address])
+get_child_implementation: public(HashMap[uint256, address])
 get_implementation: public(address)
 
-get_gauge: public(HashMap[uint256, address[MAX_UINT256]])
+get_gauge: public(HashMap[uint256, RootGauge[max_value(uint256)]])
 get_gauge_count: public(HashMap[uint256, uint256])
-is_valid_gauge: public(HashMap[address, bool])
+is_valid_gauge: public(HashMap[RootGauge, bool])
+
+zksync_reached_parity: public(bool)
 
 owner: public(address)
 future_owner: public(address)
 
 
 @external
-def __init__(_call_proxy: address, _owner: address):
+def __init__(_call_proxy: CallProxy, _owner: address):
     self.call_proxy = _call_proxy
-    log UpdateCallProxy(ZERO_ADDRESS, _call_proxy)
+    log UpdateCallProxy(empty(CallProxy), _call_proxy)
 
     self.owner = _owner
-    log TransferOwnership(ZERO_ADDRESS, _owner)
+    log TransferOwnership(empty(address), _owner)
 
 
 @external
-def transmit_emissions(_gauge: address):
+def transmit_emissions(_gauge: RootGauge):
     """
     @notice Call `transmit_emissions` on a root gauge
     @dev Entrypoint for anycall to request emissions for a child gauge.
@@ -78,34 +81,90 @@ def transmit_emissions(_gauge: address):
     # in most cases this will return True
     # for special bridges *cough cough Multichain, we can only do
     # one bridge per tx, therefore this will verify msg.sender in [tx.origin, self.call_proxy]
-    assert Bridger(RootGauge(_gauge).bridger()).check(msg.sender)
-    RootGauge(_gauge).transmit_emissions()
+    assert _gauge.bridger().check(msg.sender)
+    _gauge.transmit_emissions()
+
+
+@internal
+def _get_child(_chain_id: uint256, salt: bytes32) -> address:
+    child_factory: address = self.get_child_factory[_chain_id]
+    child_impl: bytes20 = convert(self.get_child_implementation[_chain_id], bytes20)
+    assert child_factory != empty(address)  # dev: child factory not set
+    assert child_impl != empty(bytes20)  # dev: child implementation not set
+    digest: bytes32 = empty(bytes32)
+    gauge_codehash: bytes32 = keccak256(concat(0x602d3d8160093d39f3363d3d373d3d3d363d73, child_impl, 0x5af43d82803e903d91602b57fd5bf3))
+    if _chain_id in [324, 300] and not self.zksync_reached_parity:  # zkSync
+        gauge_codehash = keccak256(concat(0x00000000000000000000602d3d8160093d39f3363d3d373d3d3d363d73, child_impl, 0x5af43d82803e903d91602b57fd5bf3))
+        digest = keccak256(concat(
+                keccak256("zksyncCreate2"),
+                convert(child_factory, bytes32),
+                salt,
+                gauge_codehash,  # bytecodeHash
+                keccak256(b""),  # inputHash
+        ))
+    else:
+        digest = keccak256(concat(0xFF, convert(child_factory, bytes20), salt, gauge_codehash))
+    return convert(convert(digest, uint256) & convert(max_value(uint160), uint256), address)
+# @version 0.3.9
+
+interface CreateAddress:
+    def compute_address(salt: bytes32, bytecode_hash: bytes32, deployer: address, input: Bytes[4096]) -> address: pure
+
+interface CreateNewAddress:
+    def create2(_salt: bytes32, _bytecode_hash: Bytes[266]): nonpayable
+
+
+_CREATE2_PREFIX: constant(bytes32) = 0x2020dba91b30cc0006188af794c2fb30dd8520db7e2c088b7fc7c103c00ca494
+FACTORY: constant(address) = 0x0000000000000000000000000000000000008006
+
+
+@external
+@pure
+def compute_address(salt: bytes32, bytecode_hash: bytes32, deployer: address, input: Bytes[4_096]=b"") -> address:
+
+    constructor_input_hash: bytes32 = keccak256(input)
+    data: bytes32 = keccak256(concat(_CREATE2_PREFIX, empty(bytes12), convert(deployer, bytes20), salt, bytecode_hash, constructor_input_hash))
+
+    return convert(convert(data, uint256) & convert(max_value(uint160), uint256), address)
+
+
+@view
+@external
+def compute_address_self(salt: bytes32, bytecode_hash: bytes32, deployer: address, input: Bytes[4096]) -> address:
+    return CreateAddress(self).compute_address(salt, bytecode_hash, deployer, input)
+
+
+@external
+def deploy_contract(_salt: bytes32, _bytecode_hash: Bytes[266]):
+    CreateNewAddress(FACTORY).create2(_salt, _bytecode_hash)
 
 
 @payable
 @external
-def deploy_gauge(_chain_id: uint256, _salt: bytes32) -> address:
+def deploy_gauge(_chain_id: uint256, _salt: bytes32) -> RootGauge:
     """
     @notice Deploy a root liquidity gauge
     @param _chain_id The chain identifier of the counterpart child gauge
     @param _salt A value to deterministically deploy a gauge
     """
-    bridger: address = self.get_bridger[_chain_id]
-    assert bridger != ZERO_ADDRESS  # dev: chain id not supported
+    bridger: Bridger = self.get_bridger[_chain_id]
+    assert bridger != empty(Bridger)  # dev: chain id not supported
 
     implementation: address = self.get_implementation
-    gauge: address = create_forwarder_to(
+    salt: bytes32 = keccak256(_abi_encode(_chain_id, msg.sender, _salt))
+    gauge: RootGauge = RootGauge(create_minimal_proxy_to(
         implementation,
         value=msg.value,
-        salt=keccak256(_abi_encode(_chain_id, msg.sender, _salt))
-    )
+        salt=salt,
+    ))
+    child: address = self._get_child(_chain_id, salt)
 
     idx: uint256 = self.get_gauge_count[_chain_id]
     self.get_gauge[_chain_id][idx] = gauge
     self.get_gauge_count[_chain_id] = idx + 1
     self.is_valid_gauge[gauge] = True
 
-    RootGauge(gauge).initialize(bridger, _chain_id)
+    gauge.initialize(bridger, _chain_id, child)
 
     log DeployedGauge(implementation, _chain_id, msg.sender, _salt, gauge)
     return gauge
@@ -113,10 +172,10 @@ def deploy_gauge(_chain_id: uint256, _salt: bytes32) -> address:
 
 @external
 def deploy_child_gauge(_chain_id: uint256, _lp_token: address, _salt: bytes32, _manager: address = msg.sender):
-    bridger: address = self.get_bridger[_chain_id]
-    assert bridger != ZERO_ADDRESS  # dev: chain id not supported
+    bridger: Bridger = self.get_bridger[_chain_id]
+    assert bridger != empty(Bridger)  # dev: chain id not supported
 
-    CallProxy(self.call_proxy).anyCall(
+    self.call_proxy.anyCall(
         self,
         _abi_encode(
             _lp_token,
@@ -124,28 +183,33 @@ def deploy_child_gauge(_chain_id: uint256, _lp_token: address, _salt: bytes32, _
             _manager,
             method_id=method_id("deploy_gauge(address,bytes32,address)")
         ),
-        ZERO_ADDRESS,
+        empty(address),
         _chain_id
     )
 
 
 @external
-def set_bridger(_chain_id: uint256, _bridger: address):
+def set_child(_chain_id: uint256, _bridger: Bridger, _child_factory: address, _child_impl: address):
     """
     @notice Set the bridger for `_chain_id`
     @param _chain_id The chain identifier to set the bridger for
     @param _bridger The bridger contract to use
+    @param _child_factory Address of factory on L2 (needed in price derivation)
+    @param _child_impl Address of gauge implementation on L2 (needed in price derivation)
     """
     assert msg.sender == self.owner  # dev: only owner
 
-    log BridgerUpdated(_chain_id, self.get_bridger[_chain_id], _bridger)
+    log ChildUpdated(_chain_id, _bridger, _child_factory, _child_impl)
     self.get_bridger[_chain_id] = _bridger
+    self.get_child_factory[_chain_id] = _child_factory
+    self.get_child_implementation[_chain_id] = _child_impl
 
 
 @external
 def set_implementation(_implementation: address):
     """
     @notice Set the implementation
+    @dev Changing implementation require change on all child factories
     @param _implementation The address of the implementation to use
     """
     assert msg.sender == self.owner  # dev: only owner
@@ -155,16 +219,26 @@ def set_implementation(_implementation: address):
 
 
 @external
-def set_call_proxy(_new_call_proxy: address):
+def set_zksync_reached_parity(_zksync_reached_parity: bool):
     """
-    @notice Set the address of the call proxy used
-    @dev _new_call_proxy should adhere to the same interface as defined
-    @param _new_call_proxy Address of the cross chain call proxy
+    @notice Update if zkSync reached parity with Ethereum on address derivation (create2)
+    @param _zksync_reached_parity True if address derivation is save for Ethereum and zkSync
     """
     assert msg.sender == self.owner
 
-    log UpdateCallProxy(self.call_proxy, _new_call_proxy)
-    self.call_proxy = _new_call_proxy
+    self.zksync_reached_parity = _zksync_reached_parity
+
+
+@external
+def set_call_proxy(_call_proxy: CallProxy):
+    """
+    @notice Set CallProxy
+    @param _call_proxy Contract to use for inter-chain communication
+    """
+    assert msg.sender == self.owner
+
+    self.call_proxy = _call_proxy
+    log UpdateCallProxy(empty(CallProxy), _call_proxy)
 
 
 @external

--- a/contracts/RootGaugeFactoryProxy.vy
+++ b/contracts/RootGaugeFactoryProxy.vy
@@ -12,6 +12,7 @@ interface Factory:
     def accept_transfer_ownership(): nonpayable
     def commit_transfer_ownership(_future_owner: address): nonpayable
     def set_child(_chain_id: uint256, _bridger: address, _child_factory: address, _child_impl: address): nonpayable
+    def set_bridger(_chain_id: uint256, _bridger: address): nonpayable
     def set_call_proxy(_new_call_proxy: address): nonpayable
     def set_implementation(_implementation: address): nonpayable
 
@@ -144,6 +145,16 @@ def set_child(_factory: Factory, _chain_id: uint256, _bridger: address, _child_f
     assert msg.sender in [self.ownership_admin, self.manager]
 
     _factory.set_child(_chain_id, _bridger, _child_factory, _child_impl)
+
+
+@external
+def set_bridger(_factory: Factory, _chain_id: uint256, _bridger: address):
+    """
+    @notice Set the bridger used for `_chain_id` on `_factory`, for older implementation
+    """
+    assert msg.sender in [self.ownership_admin, self.manager]
+
+    _factory.set_bridger(_chain_id, _bridger)
 
 
 @external

--- a/contracts/RootGaugeFactoryProxy.vy
+++ b/contracts/RootGaugeFactoryProxy.vy
@@ -9,7 +9,7 @@
 interface Factory:
     def accept_transfer_ownership(): nonpayable
     def commit_transfer_ownership(_future_owner: address): nonpayable
-    def set_bridger(_chain_id: uint256, _bridger: address): nonpayable
+    def set_child(_chain_id: uint256, _bridger: address, _child_factory: address, _child_impl: address): nonpayable
     def set_call_proxy(_new_call_proxy: address): nonpayable
     def set_implementation(_implementation: address): nonpayable
 
@@ -90,29 +90,29 @@ def set_manager(_new_manager: address):
 
 @external
 @nonreentrant('lock')
-def commit_transfer_ownership(_factory: address, _new_owner: address):
+def commit_transfer_ownership(_factory: Factory, _new_owner: address):
     """
     @notice Transfer ownership for factory `_factory` to `new_owner`
     @param _factory Factory which ownership is to be transferred
     @param _new_owner New factory owner address
     """
     assert msg.sender == self.ownership_admin, "Access denied"
-    Factory(_factory).commit_transfer_ownership(_new_owner)
+    _factory.commit_transfer_ownership(_new_owner)
 
 
 @external
 @nonreentrant('lock')
-def accept_transfer_ownership(_factory: address):
+def accept_transfer_ownership(_factory: Factory):
     """
     @notice Apply transferring ownership of `_factory`
     @param _factory Factory address
     """
-    Factory(_factory).accept_transfer_ownership()
+    _factory.accept_transfer_ownership()
 
 
 @external
 @nonreentrant('lock')
-def set_killed(_gauge: address, _is_killed: bool):
+def set_killed(_gauge: LiquidityGauge, _is_killed: bool):
     """
     @notice Set the killed status for `_gauge`
     @dev When killed, the gauge always yields a rate of 0 and so cannot mint CRV
@@ -121,37 +121,37 @@ def set_killed(_gauge: address, _is_killed: bool):
     """
     assert msg.sender in [self.ownership_admin, self.emergency_admin], "Access denied"
 
-    LiquidityGauge(_gauge).set_killed(_is_killed)
+    _gauge.set_killed(_is_killed)
 
 
 @external
 @nonreentrant('lock')
-def set_bridger(_factory: address, _chain_id: uint256, _bridger: address):
+def set_child(_factory: Factory, _chain_id: uint256, _bridger: address, _child_factory: address, _child_impl: address):
     """
-    @notice Set the bridger used for `_chain_id` on `_factory`
+    @notice Set contracts used for `_chain_id` on `_factory`
     """
     assert msg.sender in [self.ownership_admin, self.manager]
 
-    Factory(_factory).set_bridger(_chain_id, _bridger)
+    _factory.set_child(_chain_id, _bridger, _child_factory, _child_impl)
 
 
 @external
 @nonreentrant('lock')
-def set_implementation(_factory: address, _implementation: address):
+def set_implementation(_factory: Factory, _implementation: address):
     """
     @notice Set the gauge implementation used by `_factory`
     """
     assert msg.sender in [self.ownership_admin, self.manager]
 
-    Factory(_factory).set_implementation(_implementation)
+    _factory.set_implementation(_implementation)
 
 
 @external
 @nonreentrant('lock')
-def set_call_proxy(_factory: address, _new_call_proxy: address):
+def set_call_proxy(_factory: Factory, _new_call_proxy: address):
     """
     @notice Set the call proxy messenger used by `_factory`
     """
     assert msg.sender in [self.ownership_admin, self.manager]
 
-    Factory(_factory).set_call_proxy(_new_call_proxy)
+    _factory.set_call_proxy(_new_call_proxy)

--- a/contracts/RootGaugeFactoryProxy.vy
+++ b/contracts/RootGaugeFactoryProxy.vy
@@ -1,9 +1,11 @@
-# @version 0.3.3
+# pragma version 0.3.7
 """
 @title Root Gauge Factory Proxy Owner
 @license MIT
 @author CurveFi
 """
+
+version: public(constant(String[8])) = "1.0.1"
 
 
 interface Factory:
@@ -15,6 +17,7 @@ interface Factory:
 
 interface LiquidityGauge:
     def set_killed(_killed: bool): nonpayable
+    def set_child_gauge(_child: address): nonpayable
 
 
 event CommitAdmins:
@@ -89,7 +92,6 @@ def set_manager(_new_manager: address):
 
 
 @external
-@nonreentrant('lock')
 def commit_transfer_ownership(_factory: Factory, _new_owner: address):
     """
     @notice Transfer ownership for factory `_factory` to `new_owner`
@@ -101,7 +103,6 @@ def commit_transfer_ownership(_factory: Factory, _new_owner: address):
 
 
 @external
-@nonreentrant('lock')
 def accept_transfer_ownership(_factory: Factory):
     """
     @notice Apply transferring ownership of `_factory`
@@ -111,7 +112,18 @@ def accept_transfer_ownership(_factory: Factory):
 
 
 @external
-@nonreentrant('lock')
+def set_child_gauge(_root: LiquidityGauge, _child: address):
+    """
+    @notice Set child gauge address to bridge coins to
+    @param _root Root gauge address
+    @param _child Child gauge address
+    """
+    assert msg.sender == self.ownership_admin, "Access denied"
+
+    _root.set_child_gauge(_child)
+
+
+@external
 def set_killed(_gauge: LiquidityGauge, _is_killed: bool):
     """
     @notice Set the killed status for `_gauge`
@@ -125,7 +137,6 @@ def set_killed(_gauge: LiquidityGauge, _is_killed: bool):
 
 
 @external
-@nonreentrant('lock')
 def set_child(_factory: Factory, _chain_id: uint256, _bridger: address, _child_factory: address, _child_impl: address):
     """
     @notice Set contracts used for `_chain_id` on `_factory`
@@ -136,7 +147,6 @@ def set_child(_factory: Factory, _chain_id: uint256, _bridger: address, _child_f
 
 
 @external
-@nonreentrant('lock')
 def set_implementation(_factory: Factory, _implementation: address):
     """
     @notice Set the gauge implementation used by `_factory`
@@ -147,7 +157,6 @@ def set_implementation(_factory: Factory, _implementation: address):
 
 
 @external
-@nonreentrant('lock')
 def set_call_proxy(_factory: Factory, _new_call_proxy: address):
     """
     @notice Set the call proxy messenger used by `_factory`

--- a/contracts/implementations/RootGauge.vy
+++ b/contracts/implementations/RootGauge.vy
@@ -1,30 +1,27 @@
-# @version 0.3.1
+# @version 0.3.7
 """
 @title Root Liquidity Gauge Implementation
 @license MIT
 @author Curve Finance
 """
 
-
-interface Bridger:
-    def cost() -> uint256: view
-    def bridge(_token: address, _destination: address, _amount: uint256): payable
-
 interface CRV20:
     def rate() -> uint256: view
     def future_epoch_time_write() -> uint256: nonpayable
-
-interface ERC20:
     def balanceOf(_account: address) -> uint256: view
     def approve(_account: address, _value: uint256): nonpayable
     def transfer(_to: address, _amount: uint256): nonpayable
+
+interface Bridger:
+    def cost() -> uint256: view
+    def bridge(_token: CRV20, _destination: address, _amount: uint256): payable
 
 interface GaugeController:
     def checkpoint_gauge(addr: address): nonpayable
     def gauge_relative_weight(addr: address, time: uint256) -> uint256: view
 
 interface Factory:
-    def get_bridger(_chain_id: uint256) -> address: view
+    def get_bridger(_chain_id: uint256) -> Bridger: view
     def owner() -> address: view
 
 interface Minter:
@@ -42,14 +39,15 @@ RATE_DENOMINATOR: constant(uint256) = 10 ** 18
 RATE_REDUCTION_COEFFICIENT: constant(uint256) = 1189207115002721024  # 2 ** (1/4) * 1e18
 RATE_REDUCTION_TIME: constant(uint256) = YEAR
 
-CRV: immutable(address)
-GAUGE_CONTROLLER: immutable(address)
-MINTER: immutable(address)
+CRV: immutable(CRV20)
+GAUGE_CONTROLLER: immutable(GaugeController)
+MINTER: immutable(Minter)
 
 
 chain_id: public(uint256)
-bridger: public(address)
-factory: public(address)
+bridger: public(Bridger)
+child_gauge: public(address)
+factory: public(Factory)
 inflation_params: public(InflationParams)
 
 last_period: public(uint256)
@@ -59,8 +57,8 @@ is_killed: public(bool)
 
 
 @external
-def __init__(_crv_token: address, _gauge_controller: address, _minter: address):
-    self.factory = 0x000000000000000000000000000000000000dEaD
+def __init__(_crv_token: CRV20, _gauge_controller: GaugeController, _minter: Minter):
+    self.factory = Factory(0x000000000000000000000000000000000000dEaD)
 
     # assign immutable variables
     CRV = _crv_token
@@ -79,15 +77,15 @@ def transmit_emissions():
     """
     @notice Mint any new emissions and transmit across to child gauge
     """
-    assert msg.sender == self.factory  # dev: call via factory
+    assert msg.sender == self.factory.address  # dev: call via factory
 
-    Minter(MINTER).mint(self)
-    minted: uint256 = ERC20(CRV).balanceOf(self)
+    MINTER.mint(self)
+    minted: uint256 = CRV.balanceOf(self)
 
     assert minted != 0  # dev: nothing minted
-    bridger: address = self.bridger
+    bridger: Bridger = self.bridger
 
-    Bridger(bridger).bridge(CRV, self, minted, value=Bridger(bridger).cost())
+    bridger.bridge(CRV, self.child_gauge, minted, value=bridger.cost())
 
 
 @view
@@ -118,7 +116,7 @@ def user_checkpoint(_user: address) -> bool:
     # emissions up to current period (not including it)
     if last_period != current_period:
         # checkpoint the gauge filling in any missing weight data
-        GaugeController(GAUGE_CONTROLLER).checkpoint_gauge(self)
+        GAUGE_CONTROLLER.checkpoint_gauge(self)
 
         params: InflationParams = self.inflation_params
         emissions: uint256 = 0
@@ -129,7 +127,7 @@ def user_checkpoint(_user: address) -> bool:
                 # don't calculate emissions for the current period
                 break
             period_time: uint256 = i * WEEK
-            weight: uint256 = GaugeController(GAUGE_CONTROLLER).gauge_relative_weight(self, period_time)
+            weight: uint256 = GAUGE_CONTROLLER.gauge_relative_weight(self, period_time)
 
             if period_time <= params.finish_time and params.finish_time < period_time + WEEK:
                 # calculate with old rate
@@ -157,14 +155,14 @@ def set_killed(_is_killed: bool):
     @notice Set the gauge kill status
     @dev Inflation params are modified accordingly to disable/enable emissions
     """
-    assert msg.sender == Factory(self.factory).owner()
+    assert msg.sender == self.factory.owner()
 
     if _is_killed:
         self.inflation_params.rate = 0
     else:
         self.inflation_params = InflationParams({
-            rate: CRV20(CRV).rate(),
-            finish_time: CRV20(CRV).future_epoch_time_write()
+            rate: CRV.rate(),
+            finish_time: CRV.future_epoch_time_write()
         })
         self.last_period = block.timestamp / WEEK
     self.is_killed = _is_killed
@@ -177,30 +175,43 @@ def update_bridger():
     @dev Bridger contracts should prevent bridging if ever updated
     """
     # reset approval
-    bridger: address = Factory(self.factory).get_bridger(self.chain_id)
-    ERC20(CRV).approve(self.bridger, 0)
-    ERC20(CRV).approve(bridger, MAX_UINT256)
+    bridger: Bridger = self.factory.get_bridger(self.chain_id)
+    CRV.approve(self.bridger.address, 0)
+    CRV.approve(bridger.address, max_value(uint256))
     self.bridger = bridger
 
 
 @external
-def initialize(_bridger: address, _chain_id: uint256):
+def set_child_gauge(_child: address):
+    """
+    @notice Set Child contract in case something went wrong (e.g. between implementation updates)
+    @param _child Child gauge to set
+    """
+    assert msg.sender == self.factory.owner()
+    assert _child != empty(address)
+
+    self.child_gauge = _child
+
+
+@external
+def initialize(_bridger: Bridger, _chain_id: uint256, _child: address):
     """
     @notice Proxy initialization method
     """
-    assert self.factory == ZERO_ADDRESS  # dev: already initialized
+    assert self.factory == empty(Factory)  # dev: already initialized
 
+    self.child_gauge = _child
     self.chain_id = _chain_id
     self.bridger = _bridger
-    self.factory = msg.sender
+    self.factory = Factory(msg.sender)
 
     inflation_params: InflationParams = InflationParams({
-        rate: CRV20(CRV).rate(),
-        finish_time: CRV20(CRV).future_epoch_time_write()
+        rate: CRV.rate(),
+        finish_time: CRV.future_epoch_time_write()
     })
     assert inflation_params.rate != 0
 
     self.inflation_params = inflation_params
     self.last_period = block.timestamp / WEEK
 
-    ERC20(CRV).approve(_bridger, MAX_UINT256)
+    CRV.approve(_bridger.address, max_value(uint256))

--- a/contracts/implementations/RootGauge.vy
+++ b/contracts/implementations/RootGauge.vy
@@ -1,9 +1,11 @@
-# @version 0.3.7
+# pragma version 0.3.7
 """
 @title Root Liquidity Gauge Implementation
 @license MIT
 @author Curve Finance
 """
+
+version: public(constant(String[8])) = "1.0.1"
 
 interface CRV20:
     def rate() -> uint256: view
@@ -184,7 +186,7 @@ def update_bridger():
 @external
 def set_child_gauge(_child: address):
     """
-    @notice Set Child contract in case something went wrong (e.g. between implementation updates)
+    @notice Set Child contract in case something went wrong (e.g. between implementation updates or zkSync)
     @param _child Child gauge to set
     """
     assert msg.sender == self.factory.owner()

--- a/scripts/check_emissions.py
+++ b/scripts/check_emissions.py
@@ -5,6 +5,7 @@ This is due to the fact that future emissions will automatically be bridged as u
 the child chain. But when a gauge first begins ... no users will call mint, since there
 is nothing to mint.
 """
+
 from inspect import unwrap
 from itertools import compress
 

--- a/scripts/deploy.py
+++ b/scripts/deploy.py
@@ -9,7 +9,7 @@ from brownie import (
 )
 
 DEPLOYER = accounts.load("xchain_deployer", password="Xorg")
-txparams = {"from": DEPLOYER, "priority_fee": "1 gwei", "max_fee": "20 gwei"}
+# txparams = {"from": DEPLOYER, "priority_fee": "1 gwei", "max_fee": "20 gwei"}
 
 CRV = "0xD533a949740bb3306d119CC777fa900bA034cd52"
 GAUGE_CONTROLLER = "0x2F50D538606Fa9EDD2B11E2446BEb18C9D5846bB"
@@ -18,8 +18,11 @@ VE = "0x5f3b5DfEb7B28CDbD7FAba78963EE202a494e2A2"
 
 ANYCALL = ZERO_ADDRESS
 
+ROOT_FACTORY = "0x06471ED238306a427241B3eA81352244E77B004F"
+ROOT_IMPLEMENTATION = "0x9FcBca4670286367fAAF72C25F6B11078fD9F4a9"
+
 L2_CRV20 = ""
-# txparams = {"from": DEPLOYER}  # , "gas_price": "150 gwei"}
+txparams = {"from": DEPLOYER, "gas_price": "2 gwei"}
 
 
 def deploy_root():
@@ -38,8 +41,20 @@ def deploy_root():
 
 
 def deploy_child(crv_addr=L2_CRV20):
-    factory = ChildGaugeFactory.deploy(ANYCALL, crv_addr, DEPLOYER, txparams)
-    gauge_impl = ChildGauge.deploy(crv_addr, factory, txparams)
+    factory = ChildGaugeFactory.deploy(ANYCALL, ROOT_FACTORY, ROOT_IMPLEMENTATION, crv_addr, DEPLOYER, txparams)
+    gauge_impl = ChildGauge.deploy(factory, txparams)
 
     # set implementation
     factory.set_implementation(gauge_impl, txparams)
+
+    factory.commit_transfer_ownership("xgov:ownership")
+
+
+def set_child():
+    proxy = RootGaugeFactoryProxy.at("0xff12c0df72E02ab9C1fD8b986d21FF8992a8cCEE")
+
+    chain_id = 0
+    bridger = ""
+    child_factory = ""
+    child_impl = ""
+    proxy.set_child(ROOT_FACTORY, chain_id, bridger, child_factory, child_impl, txparams)

--- a/scripts/deploy.py
+++ b/scripts/deploy.py
@@ -1,8 +1,8 @@
 from brownie import (
-    RootGauge,
-    ChildGauge,
     ZERO_ADDRESS,
+    ChildGauge,
     ChildGaugeFactory,
+    RootGauge,
     RootGaugeFactory,
     RootGaugeFactoryProxy,
     accounts,

--- a/scripts/deploy.py
+++ b/scripts/deploy.py
@@ -1,36 +1,45 @@
 from brownie import (
-    ChildGauge,
-    ChildGaugeFactory,
-    ChildOracle,
     RootGauge,
+    ChildGauge,
+    ZERO_ADDRESS,
+    ChildGaugeFactory,
     RootGaugeFactory,
-    RootOracle,
+    RootGaugeFactoryProxy,
     accounts,
 )
 
-DEPLOYER = accounts.load("xchain-deployer")
+DEPLOYER = accounts.load("xchain_deployer", password="Xorg")
+txparams = {"from": DEPLOYER, "priority_fee": "1 gwei", "max_fee": "20 gwei"}
 
 CRV = "0xD533a949740bb3306d119CC777fa900bA034cd52"
 GAUGE_CONTROLLER = "0x2F50D538606Fa9EDD2B11E2446BEb18C9D5846bB"
 MINTER = "0xd061D61a4d941c39E5453435B6345Dc261C2fcE0"
 VE = "0x5f3b5DfEb7B28CDbD7FAba78963EE202a494e2A2"
 
-ANYCALL = "0x37414a8662bc1d25be3ee51fb27c2686e2490a89"
+ANYCALL = ZERO_ADDRESS
+
+L2_CRV20 = ""
+# txparams = {"from": DEPLOYER}  # , "gas_price": "150 gwei"}
 
 
 def deploy_root():
-    factory = RootGaugeFactory.deploy(ANYCALL, DEPLOYER, {"from": DEPLOYER})
-    gauge_impl = RootGauge.deploy(CRV, GAUGE_CONTROLLER, MINTER, {"from": DEPLOYER})
-    RootOracle.deploy(factory, VE, ANYCALL, {"from": DEPLOYER})
+    factory = RootGaugeFactory.deploy(ANYCALL, DEPLOYER, txparams)
+    gauge_impl = RootGauge.deploy(CRV, GAUGE_CONTROLLER, MINTER, txparams)
 
     # set implementation
-    factory.set_implementation(gauge_impl, {"from": DEPLOYER})
+    factory.set_implementation(gauge_impl, txparams)
+
+    # bridger = OptimismBridger.deploy(L2_CRV20, L1_BRIDGE, txparams)
+    # factory.set_child(5000, bridger, ...txparams)
+
+    proxy = RootGaugeFactoryProxy.deploy(txparams)
+    factory.commit_transfer_ownership(proxy, txparams)
+    proxy.accept_transfer_ownership(factory, txparams)
 
 
-def deploy_child(crv_addr):
-    factory = ChildGaugeFactory.deploy(ANYCALL, crv_addr, DEPLOYER, {"from": DEPLOYER})
-    gauge_impl = ChildGauge.deploy(crv_addr, factory, {"from": DEPLOYER})
-    ChildOracle.deploy(ANYCALL, {"from": DEPLOYER})
+def deploy_child(crv_addr=L2_CRV20):
+    factory = ChildGaugeFactory.deploy(ANYCALL, crv_addr, DEPLOYER, txparams)
+    gauge_impl = ChildGauge.deploy(crv_addr, factory, txparams)
 
     # set implementation
-    factory.set_implementation(gauge_impl, {"from": DEPLOYER})
+    factory.set_implementation(gauge_impl, txparams)

--- a/tests/child_gauge/test_approve.py
+++ b/tests/child_gauge/test_approve.py
@@ -91,9 +91,7 @@ def test_permit(accounts, bob, chain, child_gauge):
     permit = Permit(owner=alice.address, spender=bob.address, value=2**256 - 1, nonce=0)
     sig = alice.sign_message(permit)
 
-    tx = child_gauge.permit(
-        alice, bob, 2**256 - 1, 2**256 - 1, sig.v, sig.r, sig.s, {"from": bob}
-    )
+    tx = child_gauge.permit(alice, bob, 2**256 - 1, 2**256 - 1, sig.v, sig.r, sig.s, {"from": bob})
 
     assert child_gauge.allowance(alice, bob) == 2**256 - 1
 

--- a/tests/child_gauge_factory/test_child_admin_fns.py
+++ b/tests/child_gauge_factory/test_child_admin_fns.py
@@ -15,12 +15,12 @@ def test_set_voting_escrow_guarded(bob, child_gauge_factory):
         child_gauge_factory.set_voting_escrow(ETH_ADDRESS, {"from": bob})
 
 
-def test_set_implementation(alice, child_gauge_factory):
+def test_set_implementation(alice, child_gauge_impl, child_gauge_factory):
     tx = child_gauge_factory.set_implementation(ETH_ADDRESS, {"from": alice})
 
     assert child_gauge_factory.get_implementation() == ETH_ADDRESS
     assert "UpdateImplementation" in tx.events
-    assert tx.events["UpdateImplementation"].values() == [ZERO_ADDRESS, ETH_ADDRESS]
+    assert tx.events["UpdateImplementation"].values() == [child_gauge_impl.address, ETH_ADDRESS]
 
 
 def test_set_implementation_guarded(bob, child_gauge_factory):

--- a/tests/fixtures/deployments.py
+++ b/tests/fixtures/deployments.py
@@ -19,10 +19,12 @@ def child_crv_token(alice):
 
 
 @pytest.fixture(scope="module")
-def child_gauge_factory(alice, anycall, root_gauge_factory, root_gauge_impl, child_crv_token,
-                        ChildGaugeFactory):
-    factory = ChildGaugeFactory.deploy(anycall, root_gauge_factory, root_gauge_impl,
-                                       child_crv_token, alice, {"from": alice})
+def child_gauge_factory(
+    alice, anycall, root_gauge_factory, root_gauge_impl, child_crv_token, ChildGaugeFactory
+):
+    factory = ChildGaugeFactory.deploy(
+        anycall, root_gauge_factory, root_gauge_impl, child_crv_token, alice, {"from": alice}
+    )
     anycall.setWhitelist(factory, factory, 1, True, {"from": alice})
     return factory
 
@@ -138,7 +140,9 @@ def root_gauge_factory_proxy(alice, RootGaugeFactoryProxy):
 
 
 @pytest.fixture(scope="module", autouse=True)
-def set_child_factory(chain, root_gauge_factory, mock_bridger, child_gauge_factory,
-                      child_gauge_impl, alice):
-    root_gauge_factory.set_child(chain.id, mock_bridger, child_gauge_factory, child_gauge_impl,
-                                 {"from": alice})
+def set_child_factory(
+    chain, root_gauge_factory, mock_bridger, child_gauge_factory, child_gauge_impl, alice
+):
+    root_gauge_factory.set_child(
+        chain.id, mock_bridger, child_gauge_factory, child_gauge_impl, {"from": alice}
+    )

--- a/tests/fixtures/deployments.py
+++ b/tests/fixtures/deployments.py
@@ -19,8 +19,10 @@ def child_crv_token(alice):
 
 
 @pytest.fixture(scope="module")
-def child_gauge_factory(alice, anycall, child_crv_token, ChildGaugeFactory):
-    factory = ChildGaugeFactory.deploy(anycall, child_crv_token, alice, {"from": alice})
+def child_gauge_factory(alice, anycall, root_gauge_factory, root_gauge_impl, child_crv_token,
+                        ChildGaugeFactory):
+    factory = ChildGaugeFactory.deploy(anycall, root_gauge_factory, root_gauge_impl,
+                                       child_crv_token, alice, {"from": alice})
     anycall.setWhitelist(factory, factory, 1, True, {"from": alice})
     return factory
 
@@ -105,10 +107,8 @@ def root_gauge_factory(alice, anycall, chain, RootGaugeFactory):
 
 
 @pytest.fixture(scope="module")
-def mock_bridger(alice, chain, root_gauge_factory, MockBridger):
-    bridger = MockBridger.deploy({"from": alice})
-    root_gauge_factory.set_bridger(chain.id, bridger, {"from": alice})
-    return bridger
+def mock_bridger(alice, MockBridger):
+    return MockBridger.deploy({"from": alice})
 
 
 @pytest.fixture(scope="module")
@@ -135,3 +135,10 @@ def root_gauge(alice, chain, root_gauge_factory, root_gauge_impl, RootGauge):
 @pytest.fixture(scope="module")
 def root_gauge_factory_proxy(alice, RootGaugeFactoryProxy):
     return RootGaugeFactoryProxy.deploy({"from": alice})
+
+
+@pytest.fixture(scope="module", autouse=True)
+def set_child_factory(chain, root_gauge_factory, mock_bridger, child_gauge_factory,
+                      child_gauge_impl, alice):
+    root_gauge_factory.set_child(chain.id, mock_bridger, child_gauge_factory, child_gauge_impl,
+                                 {"from": alice})

--- a/tests/fixtures/deployments.py
+++ b/tests/fixtures/deployments.py
@@ -47,7 +47,7 @@ def unauthorised_token(alice):
 
 @pytest.fixture(scope="module")
 def child_gauge_impl(alice, child_crv_token, ChildGauge, child_gauge_factory):
-    impl = ChildGauge.deploy(child_crv_token, child_gauge_factory, {"from": alice})
+    impl = ChildGauge.deploy(child_gauge_factory, {"from": alice})
     child_gauge_factory.set_implementation(impl, {"from": alice})
     return impl
 

--- a/tests/forked/test_bridgers.py
+++ b/tests/forked/test_bridgers.py
@@ -104,9 +104,7 @@ def test_optimism_bridger(alice, crv_token, OptimismBridger):
         bridger.bridge(
             crv_token, alice, 2**256 - 1, 10**18, {"from": alice, "value": bridger.cost()}
         )
-    bridger.bridge(
-        crv_token, alice, 2**256 - 1, 10**17, {"from": alice, "value": bridger.cost()}
-    )
+    bridger.bridge(crv_token, alice, 2**256 - 1, 10**17, {"from": alice, "value": bridger.cost()})
 
     assert crv_token.balanceOf(optimism_bridge) == balance_before + 10**18
 

--- a/tests/root_gauge/test_checkpoint_root.py
+++ b/tests/root_gauge/test_checkpoint_root.py
@@ -57,7 +57,8 @@ def test_emissions_against_expected(alice, root_gauge_controller, root_gauge, ro
             assert rate == root_crv_token.rate()
 
 
-def test_transmit(alice, root_gauge, root_gauge_controller, mock_bridger, root_crv_token):
+def test_transmit(alice, root_gauge, child_gauge, root_gauge_controller, mock_bridger,
+                  root_crv_token):
     root_gauge_controller.add_type("Test", 10**18, {"from": alice})
     root_gauge_controller.add_gauge(root_gauge, 0, 10**18, {"from": alice})
 
@@ -66,7 +67,7 @@ def test_transmit(alice, root_gauge, root_gauge_controller, mock_bridger, root_c
     tx = root_gauge.transmit_emissions({"from": root_gauge.factory()})
     assert tx.subcalls[-1]["function"] == "bridge(address,address,uint256)"
     assert tx.subcalls[-1]["to"] == mock_bridger
-    assert tx.subcalls[-1]["inputs"]["_to"] == root_gauge
+    assert tx.subcalls[-1]["inputs"]["_to"] == child_gauge
     assert tx.subcalls[-1]["inputs"]["_token"] == root_crv_token
 
 

--- a/tests/root_gauge/test_checkpoint_root.py
+++ b/tests/root_gauge/test_checkpoint_root.py
@@ -57,8 +57,9 @@ def test_emissions_against_expected(alice, root_gauge_controller, root_gauge, ro
             assert rate == root_crv_token.rate()
 
 
-def test_transmit(alice, root_gauge, child_gauge, root_gauge_controller, mock_bridger,
-                  root_crv_token):
+def test_transmit(
+    alice, root_gauge, child_gauge, root_gauge_controller, mock_bridger, root_crv_token
+):
     root_gauge_controller.add_type("Test", 10**18, {"from": alice})
     root_gauge_controller.add_gauge(root_gauge, 0, 10**18, {"from": alice})
 

--- a/tests/root_gauge_factory/test_gauge_addresses.py
+++ b/tests/root_gauge_factory/test_gauge_addresses.py
@@ -71,39 +71,3 @@ def test_gauge_address_chain_id(
         abi=RootGauge.abi)
 
     assert root.child_gauge() == expected, "Bad child gauge calculation"
-
-
-def test_gauge_address_zksync(
-    alice,
-    root_gauge_factory,
-    child_gauge_factory,
-    lp_token,
-    child_gauge_impl,
-    MockBridger,
-    RootGauge,
-    vyper_proxy_init_code,
-):
-    chain_id = 324
-    bridger = MockBridger.deploy({"from": alice})
-    # root_gauge_factory.set_child(chain_id, bridger, child_gauge_factory, child_gauge_impl,
-    #                              {"from": alice})
-    # root = Contract.from_abi(
-    #     "Root",
-    #     root_gauge_factory.deploy_gauge(chain_id, SALT, {"from": alice}).return_value,
-    #     abi=RootGauge.abi)
-    #
-    # proxy_init_code = vyper_proxy_init_code(child_gauge_impl.address)
-    # assert root.child_gauge() == zksync_create2_address_of(
-    #     child_gauge_factory.address, salt(chain_id, alice.address), proxy_init_code
-    # ), "Bad child gauge calculation"
-
-    root_gauge_factory.set_child(chain_id, bridger,
-                                 "0x6d8Df1f19D0aF1da159D995F4cAE21bE035643AD",  # ChildFactory
-                                 "0xB66Ab9661Ca10115c75e6496410752587216F958",  # ChildGauge implementation
-                                 {"from": alice})
-    root = Contract.from_abi(
-      "Root",
-      root_gauge_factory.deploy_gauge(chain_id, SALT, {"from": "0x71F718D3e4d1449D1502A6A7595eb84eBcCB1683"}).return_value,
-      abi=RootGauge.abi)
-
-    assert root.child_gauge() == "0x131f7692cc852A80cc2e79014F694D5FE933e434", "Bad child gauge calculation"

--- a/tests/root_gauge_factory/test_gauge_addresses.py
+++ b/tests/root_gauge_factory/test_gauge_addresses.py
@@ -17,7 +17,8 @@ def zksync_create2_address_of(_addr, _salt, _initcode):
     salt = HexBytes(_salt)
     initcode = HexBytes(_initcode)
     return to_address(
-        web3.keccak(prefix + addr + salt + web3.keccak(initcode) + web3.keccak(b""))[12:])
+        web3.keccak(prefix + addr + salt + web3.keccak(initcode) + web3.keccak(b""))[12:]
+    )
 
 
 def test_gauge_address(
@@ -33,13 +34,13 @@ def test_gauge_address(
     create2_address_of,
 ):
     child = Contract.from_abi(
-        "Child",
-        child_gauge_factory.deploy_gauge(lp_token, SALT).return_value,
-        abi=ChildGauge.abi)
+        "Child", child_gauge_factory.deploy_gauge(lp_token, SALT).return_value, abi=ChildGauge.abi
+    )
     root = Contract.from_abi(
         "Root",
         root_gauge_factory.deploy_gauge(chain.id, SALT, {"from": alice}).return_value,
-        abi=RootGauge.abi)
+        abi=RootGauge.abi,
+    )
 
     assert child.root_gauge() == root, "Bad root gauge calculation"
     assert root.child_gauge() == child, "Bad child gauge calculation"
@@ -61,13 +62,16 @@ def test_gauge_address_chain_id(
     chain_id = chain.id + 1
     proxy_init_code = vyper_proxy_init_code(child_gauge_impl.address)
     expected = create2_address_of(
-        child_gauge_factory.address, salt(chain_id, alice.address), proxy_init_code)
+        child_gauge_factory.address, salt(chain_id, alice.address), proxy_init_code
+    )
     bridger = MockBridger.deploy({"from": alice})
-    root_gauge_factory.set_child(chain_id, bridger, child_gauge_factory, child_gauge_impl,
-                                 {"from": alice})
+    root_gauge_factory.set_child(
+        chain_id, bridger, child_gauge_factory, child_gauge_impl, {"from": alice}
+    )
     root = Contract.from_abi(
         "Root",
         root_gauge_factory.deploy_gauge(chain.id + 1, SALT, {"from": alice}).return_value,
-        abi=RootGauge.abi)
+        abi=RootGauge.abi,
+    )
 
     assert root.child_gauge() == expected, "Bad child gauge calculation"

--- a/tests/root_gauge_factory/test_gauge_addresses.py
+++ b/tests/root_gauge_factory/test_gauge_addresses.py
@@ -1,0 +1,109 @@
+from brownie import Contract, web3
+from brownie.convert import to_address
+from eth_abi import encode
+from hexbytes import HexBytes
+
+SALT = b"5A170000000000000000000000000000"
+
+
+def salt(chain_id, sender):
+    return web3.keccak(encode(["(uint256,address,bytes32)"], [(chain_id, sender, SALT)]))
+
+
+def zksync_create2_address_of(_addr, _salt, _initcode):
+    prefix = web3.keccak(text="zksyncCreate2")
+    addr = HexBytes(_addr)
+    addr = HexBytes(0) * 12 + addr + HexBytes(0) * (20 - len(addr))
+    salt = HexBytes(_salt)
+    initcode = HexBytes(_initcode)
+    return to_address(
+        web3.keccak(prefix + addr + salt + web3.keccak(initcode) + web3.keccak(b""))[12:])
+
+
+def test_gauge_address(
+    alice,
+    chain,
+    root_gauge_factory,
+    child_gauge_factory,
+    lp_token,
+    child_gauge_impl,
+    RootGauge,
+    ChildGauge,
+    vyper_proxy_init_code,
+    create2_address_of,
+):
+    child = Contract.from_abi(
+        "Child",
+        child_gauge_factory.deploy_gauge(lp_token, SALT).return_value,
+        abi=ChildGauge.abi)
+    root = Contract.from_abi(
+        "Root",
+        root_gauge_factory.deploy_gauge(chain.id, SALT, {"from": alice}).return_value,
+        abi=RootGauge.abi)
+
+    assert child.root_gauge() == root, "Bad root gauge calculation"
+    assert root.child_gauge() == child, "Bad child gauge calculation"
+
+
+def test_gauge_address_chain_id(
+    alice,
+    chain,
+    root_gauge_factory,
+    child_gauge_factory,
+    lp_token,
+    child_gauge_impl,
+    MockBridger,
+    RootGauge,
+    vyper_proxy_init_code,
+    create2_address_of,
+    web3,
+):
+    chain_id = chain.id + 1
+    proxy_init_code = vyper_proxy_init_code(child_gauge_impl.address)
+    expected = create2_address_of(
+        child_gauge_factory.address, salt(chain_id, alice.address), proxy_init_code)
+    bridger = MockBridger.deploy({"from": alice})
+    root_gauge_factory.set_child(chain_id, bridger, child_gauge_factory, child_gauge_impl,
+                                 {"from": alice})
+    root = Contract.from_abi(
+        "Root",
+        root_gauge_factory.deploy_gauge(chain.id + 1, SALT, {"from": alice}).return_value,
+        abi=RootGauge.abi)
+
+    assert root.child_gauge() == expected, "Bad child gauge calculation"
+
+
+def test_gauge_address_zksync(
+    alice,
+    root_gauge_factory,
+    child_gauge_factory,
+    lp_token,
+    child_gauge_impl,
+    MockBridger,
+    RootGauge,
+    vyper_proxy_init_code,
+):
+    chain_id = 324
+    bridger = MockBridger.deploy({"from": alice})
+    # root_gauge_factory.set_child(chain_id, bridger, child_gauge_factory, child_gauge_impl,
+    #                              {"from": alice})
+    # root = Contract.from_abi(
+    #     "Root",
+    #     root_gauge_factory.deploy_gauge(chain_id, SALT, {"from": alice}).return_value,
+    #     abi=RootGauge.abi)
+    #
+    # proxy_init_code = vyper_proxy_init_code(child_gauge_impl.address)
+    # assert root.child_gauge() == zksync_create2_address_of(
+    #     child_gauge_factory.address, salt(chain_id, alice.address), proxy_init_code
+    # ), "Bad child gauge calculation"
+
+    root_gauge_factory.set_child(chain_id, bridger,
+                                 "0x6d8Df1f19D0aF1da159D995F4cAE21bE035643AD",  # ChildFactory
+                                 "0xB66Ab9661Ca10115c75e6496410752587216F958",  # ChildGauge implementation
+                                 {"from": alice})
+    root = Contract.from_abi(
+      "Root",
+      root_gauge_factory.deploy_gauge(chain_id, SALT, {"from": "0x71F718D3e4d1449D1502A6A7595eb84eBcCB1683"}).return_value,
+      abi=RootGauge.abi)
+
+    assert root.child_gauge() == "0x131f7692cc852A80cc2e79014F694D5FE933e434", "Bad child gauge calculation"

--- a/tests/root_gauge_factory/test_root_factory_admin.py
+++ b/tests/root_gauge_factory/test_root_factory_admin.py
@@ -1,13 +1,13 @@
 import brownie
-from brownie import ETH_ADDRESS, ZERO_ADDRESS
+from brownie import ETH_ADDRESS
 
 
-def test_set_implementation(alice, root_gauge_factory):
+def test_set_implementation(alice, root_gauge_impl, root_gauge_factory):
     tx = root_gauge_factory.set_implementation(ETH_ADDRESS, {"from": alice})
 
     assert root_gauge_factory.get_implementation() == ETH_ADDRESS
     assert "UpdateImplementation" in tx.events
-    assert tx.events["UpdateImplementation"].values() == [ZERO_ADDRESS, ETH_ADDRESS]
+    assert tx.events["UpdateImplementation"].values() == [root_gauge_impl.address, ETH_ADDRESS]
 
 
 def test_set_implementation_guarded(bob, root_gauge_factory):
@@ -15,14 +15,17 @@ def test_set_implementation_guarded(bob, root_gauge_factory):
         root_gauge_factory.set_implementation(ETH_ADDRESS, {"from": bob})
 
 
-def test_set_bridger(alice, chain, root_gauge_factory):
-    tx = root_gauge_factory.set_bridger(chain.id, ETH_ADDRESS, {"from": alice})
+def test_set_child(alice, chain, root_gauge_factory):
+    tx = root_gauge_factory.set_child(chain.id, ETH_ADDRESS, ETH_ADDRESS, ETH_ADDRESS,
+                                      {"from": alice})
 
     assert root_gauge_factory.get_bridger(chain.id) == ETH_ADDRESS
-    assert "BridgerUpdated" in tx.events
-    assert tx.events["BridgerUpdated"].values() == [chain.id, ZERO_ADDRESS, ETH_ADDRESS]
+    assert root_gauge_factory.get_child_factory(chain.id) == ETH_ADDRESS
+    assert root_gauge_factory.get_child_implementation(chain.id) == ETH_ADDRESS
+    assert "ChildUpdated" in tx.events
+    assert tx.events["ChildUpdated"].values() == [chain.id, ETH_ADDRESS, ETH_ADDRESS, ETH_ADDRESS]
 
 
-def test_set_bridger_updated(bob, chain, root_gauge_factory):
+def test_set_child_updated(bob, chain, root_gauge_factory):
     with brownie.reverts():
-        root_gauge_factory.set_bridger(chain.id, ETH_ADDRESS, {"from": bob})
+        root_gauge_factory.set_child(chain.id, ETH_ADDRESS, ETH_ADDRESS, ETH_ADDRESS, {"from": bob})

--- a/tests/root_gauge_factory/test_root_factory_admin.py
+++ b/tests/root_gauge_factory/test_root_factory_admin.py
@@ -16,8 +16,9 @@ def test_set_implementation_guarded(bob, root_gauge_factory):
 
 
 def test_set_child(alice, chain, root_gauge_factory):
-    tx = root_gauge_factory.set_child(chain.id, ETH_ADDRESS, ETH_ADDRESS, ETH_ADDRESS,
-                                      {"from": alice})
+    tx = root_gauge_factory.set_child(
+        chain.id, ETH_ADDRESS, ETH_ADDRESS, ETH_ADDRESS, {"from": alice}
+    )
 
     assert root_gauge_factory.get_bridger(chain.id) == ETH_ADDRESS
     assert root_gauge_factory.get_child_factory(chain.id) == ETH_ADDRESS

--- a/tests/root_gauge_factory_proxy/test_root_gauge_factory_proxy_admin.py
+++ b/tests/root_gauge_factory_proxy/test_root_gauge_factory_proxy_admin.py
@@ -133,7 +133,7 @@ def test_set_killed_reverts_for_unauthorised_users(
             root_gauge_factory_proxy.set_killed(root_gauge, True, {"from": unauthorised_acct})
 
 
-def test_set_bridger_success_for_authorised_users(
+def test_set_child_success_for_authorised_users(
     root_gauge_factory,
     root_gauge_factory_proxy,
     chain,
@@ -143,14 +143,16 @@ def test_set_bridger_success_for_authorised_users(
 
     manager = root_gauge_factory_proxy.manager()
     for acct in [manager, default_owner]:
-        root_gauge_factory_proxy.set_bridger(
-            root_gauge_factory, chain.id, ETH_ADDRESS, {"from": acct}
+        root_gauge_factory_proxy.set_child(
+            root_gauge_factory, chain.id, ETH_ADDRESS, ETH_ADDRESS, ETH_ADDRESS, {"from": acct}
         )
         assert root_gauge_factory.get_bridger(chain.id) == ETH_ADDRESS
+        assert root_gauge_factory.get_child_factory(chain.id) == ETH_ADDRESS
+        assert root_gauge_factory.get_child_implementation(chain.id) == ETH_ADDRESS
         chain.undo()
 
 
-def test_set_bridger_revert_for_unauthorised_users(
+def test_set_child_revert_for_unauthorised_users(
     bob,
     charlie,
     root_gauge_factory,
@@ -162,8 +164,8 @@ def test_set_bridger_revert_for_unauthorised_users(
 
     for acct in [bob, charlie, default_e_admin]:
         with brownie.reverts():
-            root_gauge_factory_proxy.set_bridger(
-                root_gauge_factory, chain.id, ETH_ADDRESS, {"from": acct}
+            root_gauge_factory_proxy.set_child(
+                root_gauge_factory, chain.id, ETH_ADDRESS, ETH_ADDRESS, ETH_ADDRESS, {"from": acct}
             )
 
 

--- a/tests/root_gauge_factory_proxy/test_root_gauge_factory_proxy_admin.py
+++ b/tests/root_gauge_factory_proxy/test_root_gauge_factory_proxy_admin.py
@@ -169,6 +169,20 @@ def test_set_child_revert_for_unauthorised_users(
             )
 
 
+def test_set_child_gauge_success_for_authorised_users(root_gauge_factory_proxy, root_gauge, transfer_factory_ownership_to_proxy):
+    owner = root_gauge_factory_proxy.ownership_admin()
+    root_gauge_factory_proxy.set_child_gauge(root_gauge, owner, {"from": owner})
+    assert root_gauge.child_gauge() == owner
+
+
+def test_set_child_gauge_revert_for_unauthorised_users(root_gauge_factory_proxy, root_gauge, bob, charlie, default_e_admin, transfer_factory_ownership_to_proxy):
+    for acct in [bob, charlie, default_e_admin]:
+        with brownie.reverts():
+            root_gauge.set_child_gauge(acct, {"from": acct})
+        with brownie.reverts():
+            root_gauge_factory_proxy.set_child_gauge(root_gauge, acct, {"from": acct})
+
+
 def test_set_implementation_success_for_authorised_users(
     root_gauge_factory,
     root_gauge_factory_proxy,

--- a/tests/root_gauge_factory_proxy/test_root_gauge_factory_proxy_admin.py
+++ b/tests/root_gauge_factory_proxy/test_root_gauge_factory_proxy_admin.py
@@ -169,13 +169,22 @@ def test_set_child_revert_for_unauthorised_users(
             )
 
 
-def test_set_child_gauge_success_for_authorised_users(root_gauge_factory_proxy, root_gauge, transfer_factory_ownership_to_proxy):
+def test_set_child_gauge_success_for_authorised_users(
+    root_gauge_factory_proxy, root_gauge, transfer_factory_ownership_to_proxy
+):
     owner = root_gauge_factory_proxy.ownership_admin()
     root_gauge_factory_proxy.set_child_gauge(root_gauge, owner, {"from": owner})
     assert root_gauge.child_gauge() == owner
 
 
-def test_set_child_gauge_revert_for_unauthorised_users(root_gauge_factory_proxy, root_gauge, bob, charlie, default_e_admin, transfer_factory_ownership_to_proxy):
+def test_set_child_gauge_revert_for_unauthorised_users(
+    root_gauge_factory_proxy,
+    root_gauge,
+    bob,
+    charlie,
+    default_e_admin,
+    transfer_factory_ownership_to_proxy,
+):
     for acct in [bob, charlie, default_e_admin]:
         with brownie.reverts():
             root_gauge.set_child_gauge(acct, {"from": acct})


### PR DESCRIPTION
# About
zkSync address derivation is different from EVM, altered contracts so child gauges deployments can be different from root. This version will be used for curve-lite
- Made default address derivation for all chains
- `.set_child_gauge()` by DAO for ZKsync
- Remained `anyCall` functionality to be able to add support for bridgers in future