### PR TITLE
Child Gauge Implementation update

### DIFF
--- a/contracts/ChildGaugeFactory.vy
+++ b/contracts/ChildGaugeFactory.vy
@@ -166,7 +166,7 @@ def deploy_gauge(_lp_token: address, _salt: bytes32, _manager: address = msg.sen
 
     gauge_data: uint256 = 1  # set is_valid_gauge = True
     implementation: address = self.get_implementation
-    salt: bytes32 = keccak256(_abi_encode(chain.id, msg.sender, _salt))
+    salt: bytes32 = keccak256(_abi_encode(chain.id, _salt))
     gauge: address = create_minimal_proxy_to(
         implementation, salt=salt
     )

--- a/contracts/RootGaugeFactory.vy
+++ b/contracts/RootGaugeFactory.vy
@@ -114,7 +114,7 @@ def deploy_gauge(_chain_id: uint256, _salt: bytes32) -> RootGauge:
     assert bridger != empty(Bridger)  # dev: chain id not supported
 
     implementation: address = self.get_implementation
-    salt: bytes32 = keccak256(_abi_encode(_chain_id, msg.sender, _salt))
+    salt: bytes32 = keccak256(_abi_encode(_chain_id, _salt))
     gauge: RootGauge = RootGauge(create_minimal_proxy_to(
         implementation,
         value=msg.value,

--- a/contracts/implementations/ChildGauge.vy
+++ b/contracts/implementations/ChildGauge.vy
@@ -831,6 +831,18 @@ def rate_per_lp_token(_reward_id: uint256, _with_precision: bool=False) -> uint2
     return rate / precision
 
 
+@external
+@view
+def get_rewards_of(_token: ERC20) -> DynArray[RewardData, MAX_REWARDS]:
+    rewards: DynArray[RewardData, MAX_REWARDS] = []
+    for i in range(MAX_REWARDS):
+        if i >= len(self.reward_data):
+            break
+        if self.reward_data[i].token == _token:
+            rewards.append(self.reward_data[i])
+    return rewards
+
+
 @view
 @external
 def decimals() -> uint256:

--- a/contracts/implementations/ChildGauge.vy
+++ b/contracts/implementations/ChildGauge.vy
@@ -230,6 +230,9 @@ def _checkpoint_rewards(_user: address, _total_supply: uint256, _claim: bool, _r
             if _total_supply != 0:
                 integral += duration * self.reward_data[token].rate * 10**18 / _total_supply
                 self.reward_data[token].integral = integral
+            else:
+                # Return not distributed back
+                self.claim_data[data.distributor][i] += shift(duration * self.reward_data[token].rate, 128)
 
         if _user != empty(address):
             integral_for: uint256 = self.reward_integral_for[token][_user]

--- a/contracts/implementations/ChildGauge.vy
+++ b/contracts/implementations/ChildGauge.vy
@@ -561,6 +561,7 @@ def add_reward(_reward_token: address, _distributor: address):
     @notice Set the active reward contract
     """
     assert msg.sender == self.manager or msg.sender == FACTORY.owner()
+    assert _reward_token != FACTORY.crv()
 
     reward_count: uint256 = self.reward_count
     assert reward_count < MAX_REWARDS

--- a/contracts/implementations/ChildGauge.vy
+++ b/contracts/implementations/ChildGauge.vy
@@ -232,7 +232,7 @@ def _checkpoint_rewards(_user: address, _total_supply: uint256, _claim: bool, _r
                 self.reward_data[token].integral = integral
             else:
                 # Return not distributed back
-                self.claim_data[data.distributor][i] += shift(duration * self.reward_data[token].rate, 128)
+                self.claim_data[self.reward_data[token].distributor][token] += shift(duration * self.reward_data[token].rate, 128)
 
         if _user != empty(address):
             integral_for: uint256 = self.reward_integral_for[token][_user]
@@ -561,7 +561,7 @@ def add_reward(_reward_token: address, _distributor: address):
     @notice Set the active reward contract
     """
     assert msg.sender == self.manager or msg.sender == FACTORY.owner()
-    assert _reward_token != FACTORY.crv()
+    assert _reward_token != FACTORY.crv().address
 
     reward_count: uint256 = self.reward_count
     assert reward_count < MAX_REWARDS

--- a/contracts/implementations/ChildGauge.vy
+++ b/contracts/implementations/ChildGauge.vy
@@ -1,12 +1,11 @@
 # pragma version 0.3.7
+# pragma optimize gas
 """
 @title CurveXChainLiquidityGauge
 @license Copyright (c) Curve.Fi, 2020-2024 - all rights reserved
 @author Curve.Fi
 @notice Layer2/Cross-Chain Gauge
 """
-
-version: public(constant(String[8])) = "0.2.1"
 
 
 from vyper.interfaces import ERC20
@@ -15,7 +14,10 @@ implements: ERC20
 
 
 interface ERC20Extended:
-    def symbol() -> String[26]: view
+    def symbol() -> String[32]: view
+
+interface ERC1271:
+    def isValidSignature(_hash: bytes32, _signature: Bytes[65]) -> bytes32: view
 
 interface Factory:
     def owner() -> address: view
@@ -23,34 +25,35 @@ interface Factory:
     def minted(_user: address, _gauge: address) -> uint256: view
     def crv() -> ERC20: view
 
-interface ERC1271:
-    def isValidSignature(_hash: bytes32, _signature: Bytes[65]) -> bytes32: view
 
+event Deposit:
+    provider: indexed(address)
+    value: uint256
 
-event Approval:
-    _owner: indexed(address)
-    _spender: indexed(address)
-    _value: uint256
+event Withdraw:
+    provider: indexed(address)
+    value: uint256
+
+event UpdateLiquidityLimit:
+    user: indexed(address)
+    original_balance: uint256
+    original_supply: uint256
+    working_balance: uint256
+    working_supply: uint256
+
+event SetGaugeManager:
+    _gauge_manager: address
+
 
 event Transfer:
     _from: indexed(address)
     _to: indexed(address)
     _value: uint256
 
-event Deposit:
-    _user: indexed(address)
+event Approval:
+    _owner: indexed(address)
+    _spender: indexed(address)
     _value: uint256
-
-event Withdraw:
-    _user: indexed(address)
-    _value: uint256
-
-event UpdateLiquidityLimit:
-    _user: indexed(address)
-    _original_balance: uint256
-    _original_supply: uint256
-    _working_balance: uint256
-    _working_supply: uint256
 
 
 struct Reward:
@@ -61,57 +64,77 @@ struct Reward:
     integral: uint256
 
 
-DOMAIN_TYPE_HASH: constant(bytes32) = keccak256("EIP712Domain(string name,string version,uint256 chainId,address verifyingContract)")
-PERMIT_TYPE_HASH: constant(bytes32) = keccak256("Permit(address owner,address spender,uint256 value,uint256 nonce,uint256 deadline)")
-ERC1271_MAGIC_VAL: constant(bytes32) = 0x1626ba7e00000000000000000000000000000000000000000000000000000000
-
 MAX_REWARDS: constant(uint256) = 8
 TOKENLESS_PRODUCTION: constant(uint256) = 40
-WEEK: constant(uint256) = 86400 * 7
+WEEK: constant(uint256) = 604800
+
+VERSION: constant(String[8]) = "1.0.0"
+
+EIP712_TYPEHASH: constant(bytes32) = keccak256("EIP712Domain(string name,string version,uint256 chainId,address verifyingContract)")
+EIP2612_TYPEHASH: constant(bytes32) = keccak256("Permit(address owner,address spender,uint256 value,uint256 nonce,uint256 deadline)")
 
 
-FACTORY: immutable(Factory)
+voting_escrow: public(address)
 
 
+# ERC20
+balanceOf: public(HashMap[address, uint256])
+totalSupply: public(uint256)
+allowance: public(HashMap[address, HashMap[address, uint256]])
+
+name: public(String[64])
+symbol: public(String[40])
+
+# ERC2612
 DOMAIN_SEPARATOR: public(bytes32)
 nonces: public(HashMap[address, uint256])
 
-name: public(String[64])
-symbol: public(String[32])
-
-allowance: public(HashMap[address, HashMap[address, uint256]])
-balanceOf: public(HashMap[address, uint256])
-totalSupply: public(uint256)
-
-lp_token: public(address)
+# Gauge
+FACTORY: immutable(Factory)
 manager: public(address)
+lp_token: public(address)
 
-voting_escrow: public(address)
-working_balances: public(HashMap[address, uint256])
-working_supply: public(uint256)
+is_killed: public(bool)
 
-period: public(uint256)
-period_timestamp: public(HashMap[uint256, uint256])
-
-integrate_checkpoint_of: public(HashMap[address, uint256])
-integrate_fraction: public(HashMap[address, uint256])
-integrate_inv_supply: public(HashMap[uint256, uint256])
-integrate_inv_supply_of: public(HashMap[address, uint256])
+inflation_rate: public(HashMap[uint256, uint256])
 
 # For tracking external rewards
 reward_count: public(uint256)
-reward_tokens: public(address[MAX_REWARDS])
 reward_data: public(HashMap[address, Reward])
+reward_remaining: public(HashMap[address, uint256])  # fixes bad precision
+
 # claimant -> default reward receiver
 rewards_receiver: public(HashMap[address, address])
+
 # reward token -> claiming address -> integral
 reward_integral_for: public(HashMap[address, HashMap[address, uint256]])
-# user -> token -> [uint128 claimable amount][uint128 claimed amount]
+
+# user -> [uint128 claimable amount][uint128 claimed amount]
 claim_data: HashMap[address, HashMap[address, uint256]]
 
-is_killed: public(bool)
-inflation_rate: public(HashMap[uint256, uint256])
+working_balances: public(HashMap[address, uint256])
+working_supply: public(uint256)
 
+# 1e18 * ∫(rate(t) / totalSupply(t) dt) from (last_action) till checkpoint
+integrate_inv_supply_of: public(HashMap[address, uint256])
+integrate_checkpoint_of: public(HashMap[address, uint256])
+
+# ∫(balance * rate(t) / totalSupply(t) dt) from 0 till checkpoint
+# Units: rate * t = already number of coins per address to issue
+integrate_fraction: public(HashMap[address, uint256])
+
+# The goal is to be able to calculate ∫(rate * balance / totalSupply dt) from 0 till checkpoint
+# All values are kept in units of being multiplied by 1e18
+period: public(int128)
+
+# array of reward tokens
+reward_tokens: public(address[MAX_REWARDS])
+
+period_timestamp: public(HashMap[int128, uint256])
+# 1e18 * ∫(rate(t) / totalSupply(t) dt) from 0 till checkpoint
+integrate_inv_supply: public(HashMap[int128, uint256])
+
+# custom xchain parameters
 root_gauge: public(address)
 
 
@@ -122,13 +145,44 @@ def __init__(_factory: Factory):
     FACTORY = _factory
 
 
+@external
+def initialize(_lp_token: address, _root: address, _manager: address):
+    assert self.lp_token == empty(address)  # dev: already initialized
+
+    self.lp_token = _lp_token
+    self.root_gauge = _root
+    self.manager = _manager
+
+    self.voting_escrow = Factory(msg.sender).voting_escrow()
+
+    symbol: String[32] = ERC20Extended(_lp_token).symbol()
+    name: String[64] = concat("Curve.fi ", symbol, " Gauge Deposit")
+
+    self.name = name
+    self.symbol = concat(symbol, "-gauge")
+
+    self.period_timestamp[0] = block.timestamp
+    self.DOMAIN_SEPARATOR = keccak256(
+        _abi_encode(
+            EIP712_TYPEHASH,
+            keccak256(name),
+            keccak256(VERSION),
+            chain.id,
+            self
+        )
+    )
+
+
+# Internal Functions
+
+
 @internal
 def _checkpoint(_user: address):
     """
     @notice Checkpoint a user calculating their CRV entitlement
     @param _user User address
     """
-    period: uint256 = self.period
+    period: int128 = self.period
     period_time: uint256 = self.period_timestamp[period]
     integrate_inv_supply: uint256 = self.integrate_inv_supply[period]
 
@@ -174,6 +228,65 @@ def _checkpoint(_user: address):
 
 
 @internal
+def _checkpoint_rewards(_user: address, _total_supply: uint256, _claim: bool, _receiver: address):
+    """
+    @notice Claim pending rewards and checkpoint rewards for a user
+    """
+
+    user_balance: uint256 = 0
+    receiver: address = _receiver
+    if _user != empty(address):
+        user_balance = self.balanceOf[_user]
+        if _claim and _receiver == empty(address):
+            # if receiver is not explicitly declared, check if a default receiver is set
+            receiver = self.rewards_receiver[_user]
+            if receiver == empty(address):
+                # if no default receiver is set, direct claims to the user
+                receiver = _user
+
+    reward_count: uint256 = self.reward_count
+    for i in range(MAX_REWARDS):
+        if i == reward_count:
+            break
+        token: address = self.reward_tokens[i]
+
+        integral: uint256 = self.reward_data[token].integral
+        period_finish: uint256 = self.reward_data[token].period_finish
+        last_update: uint256 = min(block.timestamp, period_finish)
+        duration: uint256 = last_update - self.reward_data[token].last_update
+
+        if duration != 0 and _total_supply != 0:
+            self.reward_data[token].last_update = last_update
+
+            rate: uint256 = self.reward_data[token].rate
+            excess: uint256 = self.reward_remaining[token] - (period_finish - last_update + duration) * rate
+            integral_change: uint256 = (duration * rate + excess) * 10**18 / _total_supply
+            integral += integral_change
+            self.reward_data[token].integral = integral
+            # There is still calculation error in user's claimable amount,
+            # but it has 18-decimal precision through LP(_total_supply) – safe
+            self.reward_remaining[token] -= integral_change * _total_supply / 10**18
+
+        if _user != empty(address):
+            integral_for: uint256 = self.reward_integral_for[token][_user]
+            new_claimable: uint256 = 0
+
+            if integral_for < integral:
+                self.reward_integral_for[token][_user] = integral
+                new_claimable = user_balance * (integral - integral_for) / 10**18
+
+            claim_data: uint256 = self.claim_data[_user][token]
+            total_claimable: uint256 = shift(claim_data, -128) + new_claimable
+            if total_claimable > 0:
+                total_claimed: uint256 = claim_data % 2**128
+                if _claim:
+                    assert ERC20(token).transfer(receiver, total_claimable, default_return_value=True)
+                    self.claim_data[_user][token] = total_claimed + total_claimable
+                elif new_claimable > 0:
+                    self.claim_data[_user][token] = total_claimed + shift(total_claimable, 128)
+
+
+@internal
 def _update_liquidity_limit(_user: address, _user_balance: uint256, _total_supply: uint256):
     """
     @notice Calculate working balances to apply amplification of CRV production.
@@ -201,178 +314,159 @@ def _update_liquidity_limit(_user: address, _user_balance: uint256, _total_suppl
 
 
 @internal
-def _checkpoint_rewards(_user: address, _total_supply: uint256, _claim: bool, _receiver: address):
-    """
-    @notice Claim pending rewards and checkpoint rewards for a user
-    """
-    user_balance: uint256 = 0
-    receiver: address = _receiver
-    if _user != empty(address):
-        user_balance = self.balanceOf[_user]
-        if _claim and _receiver == empty(address):
-            # if receiver is not explicitly declared, check if a default receiver is set
-            receiver = self.rewards_receiver[_user]
-            if receiver == empty(address):
-                # if no default receiver is set, direct claims to the user
-                receiver = _user
-
-    reward_count: uint256 = self.reward_count
-    for i in range(MAX_REWARDS):
-        if i == reward_count:
-            break
-        token: address = self.reward_tokens[i]
-
-        integral: uint256 = self.reward_data[token].integral
-        last_update: uint256 = min(block.timestamp, self.reward_data[token].period_finish)
-        duration: uint256 = last_update - self.reward_data[token].last_update
-        if duration != 0:
-            self.reward_data[token].last_update = last_update
-            if _total_supply != 0:
-                integral += duration * self.reward_data[token].rate * 10**18 / _total_supply
-                self.reward_data[token].integral = integral
-            else:
-                # Return not distributed back
-                self.claim_data[self.reward_data[token].distributor][token] +=\
-                    shift(duration * self.reward_data[token].rate, 128)
-
-        if _user != empty(address):
-            integral_for: uint256 = self.reward_integral_for[token][_user]
-            new_claimable: uint256 = 0
-
-            if integral_for < integral:
-                self.reward_integral_for[token][_user] = integral
-                new_claimable = user_balance * (integral - integral_for) / 10**18
-
-            claim_data: uint256 = self.claim_data[_user][token]
-            total_claimable: uint256 = shift(claim_data, -128) + new_claimable
-            if total_claimable > 0:
-                total_claimed: uint256 = claim_data % 2**128
-                if _claim:
-                    assert ERC20(token).transfer(receiver, total_claimable, default_return_value=True)
-                    self.claim_data[_user][token] = total_claimed + total_claimable
-                elif new_claimable > 0:
-                    self.claim_data[_user][token] = total_claimed + shift(total_claimable, 128)
-
-
-@internal
 def _transfer(_from: address, _to: address, _value: uint256):
-    if _value == 0:
-        return
-    total_supply: uint256 = self.totalSupply
+    """
+    @notice Transfer tokens as well as checkpoint users
+    """
+    self._checkpoint(_from)
+    self._checkpoint(_to)
 
-    has_rewards: bool = self.reward_count != 0
-    for addr in [_from, _to]:
-        self._checkpoint(addr)
-        self._checkpoint_rewards(addr, total_supply, False, empty(address))
+    if _value != 0:
+        total_supply: uint256 = self.totalSupply
+        is_rewards: bool = self.reward_count != 0
+        if is_rewards:
+            self._checkpoint_rewards(_from, total_supply, False, empty(address))
+        new_balance: uint256 = self.balanceOf[_from] - _value
+        self.balanceOf[_from] = new_balance
+        self._update_liquidity_limit(_from, new_balance, total_supply)
 
-    new_balance: uint256 = self.balanceOf[_from] - _value
-    self.balanceOf[_from] = new_balance
-    self._update_liquidity_limit(_from, new_balance, total_supply)
-
-    new_balance = self.balanceOf[_to] + _value
-    self.balanceOf[_to] = new_balance
-    self._update_liquidity_limit(_to, new_balance, total_supply)
+        if is_rewards:
+            self._checkpoint_rewards(_to, total_supply, False, empty(address))
+        new_balance = self.balanceOf[_to] + _value
+        self.balanceOf[_to] = new_balance
+        self._update_liquidity_limit(_to, new_balance, total_supply)
 
     log Transfer(_from, _to, _value)
 
 
+# External User Facing Functions
+
+
 @external
-@nonreentrant("lock")
-def deposit(_value: uint256, _user: address = msg.sender, _claim_rewards: bool = False):
+@nonreentrant('lock')
+def deposit(_value: uint256, _addr: address = msg.sender, _claim_rewards: bool = False):
     """
     @notice Deposit `_value` LP tokens
+    @dev Depositting also claims pending reward tokens
     @param _value Number of tokens to deposit
-    @param _user The account to send gauge tokens to
+    @param _addr Address to deposit for
     """
-    self._checkpoint(_user)
-    if _value == 0:
-        return
+    assert _addr != empty(address)  # dev: cannot deposit for zero address
+    self._checkpoint(_addr)
 
-    total_supply: uint256 = self.totalSupply
-    new_balance: uint256 = self.balanceOf[_user] + _value
+    if _value != 0:
+        is_rewards: bool = self.reward_count != 0
+        total_supply: uint256 = self.totalSupply
+        if is_rewards:
+            self._checkpoint_rewards(_addr, total_supply, _claim_rewards, empty(address))
 
-    if self.reward_count != 0:
-        self._checkpoint_rewards(_user, total_supply, _claim_rewards, empty(address))
+        total_supply += _value
+        new_balance: uint256 = self.balanceOf[_addr] + _value
+        self.balanceOf[_addr] = new_balance
+        self.totalSupply = total_supply
 
-    total_supply += _value
+        self._update_liquidity_limit(_addr, new_balance, total_supply)
 
-    self.balanceOf[_user] = new_balance
-    self.totalSupply = total_supply
+        ERC20(self.lp_token).transferFrom(msg.sender, self, _value)
 
-    self._update_liquidity_limit(_user, new_balance, total_supply)
-
-    ERC20(self.lp_token).transferFrom(msg.sender, self, _value)
-
-    log Deposit(_user, _value)
-    log Transfer(empty(address), _user, _value)
+        log Deposit(_addr, _value)
+        log Transfer(empty(address), _addr, _value)
 
 
 @external
-@nonreentrant("lock")
-def withdraw(_value: uint256, _user: address = msg.sender, _claim_rewards: bool = False):
+@nonreentrant('lock')
+def withdraw(_value: uint256, _claim_rewards: bool = False):
     """
     @notice Withdraw `_value` LP tokens
+    @dev Withdrawing also claims pending reward tokens
     @param _value Number of tokens to withdraw
-    @param _user The account to send LP tokens to
     """
-    self._checkpoint(_user)
-    if _value == 0:
-        return
+    self._checkpoint(msg.sender)
 
-    total_supply: uint256 = self.totalSupply
-    new_balance: uint256 = self.balanceOf[msg.sender] - _value
+    if _value != 0:
+        is_rewards: bool = self.reward_count != 0
+        total_supply: uint256 = self.totalSupply
+        if is_rewards:
+            self._checkpoint_rewards(msg.sender, total_supply, _claim_rewards, empty(address))
 
-    if self.reward_count != 0:
-        self._checkpoint_rewards(_user, total_supply, _claim_rewards, empty(address))
+        total_supply -= _value
+        new_balance: uint256 = self.balanceOf[msg.sender] - _value
+        self.balanceOf[msg.sender] = new_balance
+        self.totalSupply = total_supply
 
-    total_supply -= _value
+        self._update_liquidity_limit(msg.sender, new_balance, total_supply)
 
-    self.balanceOf[msg.sender] = new_balance
-    self.totalSupply = total_supply
+        ERC20(self.lp_token).transfer(msg.sender, _value)
 
-    self._update_liquidity_limit(msg.sender, new_balance, total_supply)
-
-    ERC20(self.lp_token).transfer(_user, _value)
-
-    log Withdraw(_user, _value)
+    log Withdraw(msg.sender, _value)
     log Transfer(msg.sender, empty(address), _value)
 
 
 @external
-@nonreentrant("lock")
-def transferFrom(_from: address, _to: address, _value: uint256) -> bool:
+@nonreentrant('lock')
+def claim_rewards(_addr: address = msg.sender, _receiver: address = empty(address)):
     """
-    @notice Transfer tokens from one address to another
-    @param _from The address which you want to send tokens from
-    @param _to The address which you want to transfer to
-    @param _value the amount of tokens to be transferred
-    @return bool success
+    @notice Claim available reward tokens for `_addr`
+    @param _addr Address to claim for
+    @param _receiver Address to transfer rewards to - if set to
+                     empty(address), uses the default reward receiver
+                     for the caller
     """
-    allowance: uint256 = self.allowance[_from][msg.sender]
-    if allowance != max_value(uint256):
-        self.allowance[_from][msg.sender] = allowance - _value
+    if _receiver != empty(address):
+        assert _addr == msg.sender  # dev: cannot redirect when claiming for another user
+    self._checkpoint_rewards(_addr, self.totalSupply, True, _receiver)
+
+
+@external
+@nonreentrant('lock')
+def transferFrom(_from: address, _to :address, _value: uint256) -> bool:
+    """
+     @notice Transfer tokens from one address to another.
+     @dev Transferring claims pending reward tokens for the sender and receiver
+     @param _from address The address which you want to send tokens from
+     @param _to address The address which you want to transfer to
+     @param _value uint256 the amount of tokens to be transferred
+    """
+    _allowance: uint256 = self.allowance[_from][msg.sender]
+    if _allowance != max_value(uint256):
+        self.allowance[_from][msg.sender] = _allowance - _value
 
     self._transfer(_from, _to, _value)
+
     return True
 
 
 @external
-def approve(_spender: address, _value: uint256) -> bool:
+@nonreentrant('lock')
+def transfer(_to: address, _value: uint256) -> bool:
+    """
+    @notice Transfer token for a specified address
+    @dev Transferring claims pending reward tokens for the sender and receiver
+    @param _to The address to transfer to.
+    @param _value The amount to be transferred.
+    """
+    self._transfer(msg.sender, _to, _value)
+
+    return True
+
+
+@external
+def approve(_spender : address, _value : uint256) -> bool:
     """
     @notice Approve the passed address to transfer the specified amount of
             tokens on behalf of msg.sender
     @dev Beware that changing an allowance via this method brings the risk
          that someone may use both the old and new allowance by unfortunate
          transaction ordering. This may be mitigated with the use of
-         {increaseAllowance} and {decreaseAllowance}.
+         {incraseAllowance} and {decreaseAllowance}.
          https://github.com/ethereum/EIPs/issues/20#issuecomment-263524729
     @param _spender The address which will transfer the funds
     @param _value The amount of tokens that may be transferred
     @return bool success
     """
     self.allowance[msg.sender][_spender] = _value
-
     log Approval(msg.sender, _spender, _value)
+
     return True
 
 
@@ -401,41 +495,27 @@ def permit(
     @param _s The bytes[32:64] of the valid secp256k1 signature of permit by owner
     @return True, if transaction completes successfully
     """
-    assert _owner != empty(address)
-    assert block.timestamp <= _deadline
+    assert _owner != empty(address)  # dev: invalid owner
+    assert block.timestamp <= _deadline  # dev: permit expired
 
     nonce: uint256 = self.nonces[_owner]
     digest: bytes32 = keccak256(
         concat(
             b"\x19\x01",
             self.DOMAIN_SEPARATOR,
-            keccak256(_abi_encode(PERMIT_TYPE_HASH, _owner, _spender, _value, nonce, _deadline))
+            keccak256(
+                _abi_encode(
+                    EIP2612_TYPEHASH, _owner, _spender, _value, nonce, _deadline
+                )
+            ),
         )
     )
-
-    if _owner.is_contract:
-        sig: Bytes[65] = concat(_abi_encode(_r, _s), slice(convert(_v, bytes32), 31, 1))
-        assert ERC1271(_owner).isValidSignature(digest, sig) == ERC1271_MAGIC_VAL
-    else:
-        assert ecrecover(digest, convert(_v, uint256), convert(_r, uint256), convert(_s, uint256)) == _owner
+    assert ecrecover(digest, _v, _r, _s) == _owner  # dev: invalid signature
 
     self.allowance[_owner][_spender] = _value
-    self.nonces[_owner] = nonce + 1
+    self.nonces[_owner] = unsafe_add(nonce, 1)
 
     log Approval(_owner, _spender, _value)
-    return True
-
-
-@external
-@nonreentrant("lock")
-def transfer(_to: address, _value: uint256) -> bool:
-    """
-    @notice Transfer token to a specified address
-    @param _to The address to transfer to
-    @param _value The amount to be transferred
-    @return bool success
-    """
-    self._transfer(msg.sender, _to, _value)
     return True
 
 
@@ -453,6 +533,7 @@ def increaseAllowance(_spender: address, _added_value: uint256) -> bool:
     self.allowance[msg.sender][_spender] = allowance
 
     log Approval(msg.sender, _spender, allowance)
+
     return True
 
 
@@ -470,6 +551,7 @@ def decreaseAllowance(_spender: address, _subtracted_value: uint256) -> bool:
     self.allowance[msg.sender][_spender] = allowance
 
     log Approval(msg.sender, _spender, allowance)
+
     return True
 
 
@@ -487,14 +569,167 @@ def user_checkpoint(addr: address) -> bool:
 
 
 @external
-def claimable_tokens(addr: address) -> uint256:
+def set_rewards_receiver(_receiver: address):
     """
-    @notice Get the number of claimable tokens per user
-    @dev This function should be manually changed to "view" in the ABI
-    @return uint256 number of claimable tokens per user
+    @notice Set the default reward receiver for the caller.
+    @dev When set to empty(address), rewards are sent to the caller
+    @param _receiver Receiver address for any rewards claimed via `claim_rewards`
     """
-    self._checkpoint(addr)
-    return self.integrate_fraction[addr] - FACTORY.minted(addr, self)
+    self.rewards_receiver[msg.sender] = _receiver
+
+
+# Administrative Functions
+
+
+@external
+def set_gauge_manager(_gauge_manager: address):
+    """
+    @notice Change the gauge manager for a gauge
+    @dev The manager of this contract, or the ownership admin can outright modify gauge
+        managership. A gauge manager can also transfer managership to a new manager via this
+        method, but only for the gauge which they are the manager of.
+    @param _gauge_manager The account to set as the new manager of the gauge.
+    """
+    assert msg.sender in [self.manager, FACTORY.owner()]  # dev: only manager or factory admin
+
+    self.manager = _gauge_manager
+    log SetGaugeManager(_gauge_manager)
+
+
+@external
+def set_manager(_gauge_manager: address):
+    """
+    @notice Change the gauge manager for a gauge
+    @dev Copy of `set_gauge_manager` for back-compatability
+    @dev The manager of this contract, or the ownership admin can outright modify gauge
+        managership. A gauge manager can also transfer managership to a new manager via this
+        method, but only for the gauge which they are the manager of.
+    @param _gauge_manager The account to set as the new manager of the gauge.
+    """
+    assert msg.sender in [self.manager, FACTORY.owner()]  # dev: only manager or factory admin
+
+    self.manager = _gauge_manager
+    log SetGaugeManager(_gauge_manager)
+
+
+@external
+@nonreentrant("lock")
+def deposit_reward_token(_reward_token: address, _amount: uint256, _epoch: uint256 = WEEK):
+    """
+    @notice Deposit a reward token for distribution
+    @param _reward_token The reward token being deposited
+    @param _amount The amount of `_reward_token` being deposited
+    @param _epoch The duration the rewards are distributed across. Between 3 days and a year, week by default
+    """
+    assert msg.sender == self.reward_data[_reward_token].distributor
+    assert 3 * WEEK / 7 <= _epoch and _epoch <= WEEK * 4 * 12, "Epoch duration"
+
+    self._checkpoint_rewards(empty(address), self.totalSupply, False, empty(address))
+
+    # transferFrom reward token and use transferred amount henceforth:
+    amount_received: uint256 = ERC20(_reward_token).balanceOf(self)
+    assert ERC20(_reward_token).transferFrom(
+        msg.sender,
+        self,
+        _amount,
+        default_return_value=True
+    )
+    amount_received = ERC20(_reward_token).balanceOf(self) - amount_received
+
+    total_amount: uint256 = amount_received + self.reward_remaining[_reward_token]
+    self.reward_data[_reward_token].rate = total_amount / _epoch
+    self.reward_remaining[_reward_token] = total_amount
+
+    self.reward_data[_reward_token].last_update = block.timestamp
+    self.reward_data[_reward_token].period_finish = block.timestamp + _epoch
+
+
+@external
+def recover_remaining(_reward_token: address):
+    """
+    @notice Recover reward token remaining after calculation errors. Helpful for small decimal tokens.
+    Remaining tokens will be claimable in favor of distributor. Callable by anyone after reward distribution finished.
+    @param _reward_token The reward token being recovered
+    """
+    self._checkpoint_rewards(empty(address), self.totalSupply, False, empty(address))
+
+    period_finish: uint256 = self.reward_data[_reward_token].period_finish
+    assert period_finish < block.timestamp
+    assert self.reward_data[_reward_token].last_update >= period_finish
+
+    assert ERC20(_reward_token).transfer(self.reward_data[_reward_token].distributor,
+        self.reward_remaining[_reward_token], default_return_value=True)
+    self.reward_remaining[_reward_token] = 0
+
+
+@external
+def add_reward(_reward_token: address, _distributor: address):
+    """
+    @notice Add additional rewards to be distributed to stakers
+    @param _reward_token The token to add as an additional reward
+    @param _distributor Address permitted to fund this contract with the reward token
+    """
+    assert msg.sender in [self.manager, FACTORY.owner()]  # dev: only manager or factory admin
+    assert _distributor != empty(address)  # dev: distributor cannot be zero address
+
+    reward_count: uint256 = self.reward_count
+    assert reward_count < MAX_REWARDS
+    assert self.reward_data[_reward_token].distributor == empty(address)
+
+    self.reward_data[_reward_token].distributor = _distributor
+    self.reward_tokens[reward_count] = _reward_token
+    self.reward_count = reward_count + 1
+
+
+@external
+def set_reward_distributor(_reward_token: address, _distributor: address):
+    """
+    @notice Reassign the reward distributor for a reward token
+    @param _reward_token The reward token to reassign distribution rights to
+    @param _distributor The address of the new distributor
+    """
+    current_distributor: address = self.reward_data[_reward_token].distributor
+
+    assert msg.sender in [current_distributor, FACTORY.owner(), self.manager]
+    assert current_distributor != empty(address)
+    assert _distributor != empty(address)
+
+    self.reward_data[_reward_token].distributor = _distributor
+
+
+@external
+def set_killed(_is_killed: bool):
+    """
+    @notice Set the killed status for this contract
+    @dev When killed, the gauge always yields a rate of 0 and so cannot mint CRV
+    @param _is_killed Killed status to set
+    """
+    assert msg.sender == FACTORY.owner()  # dev: only owner
+
+    self.is_killed = _is_killed
+
+
+@external
+def set_root_gauge(_root: address):
+    """
+    @notice Set Root contract in case something went wrong (e.g. between implementation updates)
+    @param _root Root gauge to set
+    """
+    assert msg.sender == FACTORY.owner()
+    assert _root != empty(address)
+
+    self.root_gauge = _root
+
+
+@external
+def update_voting_escrow():
+    """
+    @notice Update the voting escrow contract in storage
+    """
+    self.voting_escrow = FACTORY.voting_escrow()
+
+
+# View Methods
 
 
 @view
@@ -532,183 +767,46 @@ def claimable_reward(_user: address, _reward_token: address) -> uint256:
 
 
 @external
-def set_rewards_receiver(_receiver: address):
+def claimable_tokens(addr: address) -> uint256:
     """
-    @notice Set the default reward receiver for the caller.
-    @dev When set to ZERO_ADDRESS, rewards are sent to the caller
-    @param _receiver Receiver address for any rewards claimed via `claim_rewards`
+    @notice Get the number of claimable tokens per user
+    @dev This function should be manually changed to "view" in the ABI
+    @return uint256 number of claimable tokens per user
     """
-    self.rewards_receiver[msg.sender] = _receiver
+    self._checkpoint(addr)
+    return self.integrate_fraction[addr] - FACTORY.minted(addr, self)
 
 
+@view
 @external
-@nonreentrant('lock')
-def claim_rewards(_addr: address = msg.sender, _receiver: address = empty(address)):
+def integrate_checkpoint() -> uint256:
     """
-    @notice Claim available reward tokens for `_addr`
-    @param _addr Address to claim for
-    @param _receiver Address to transfer rewards to - if set to
-                     ZERO_ADDRESS, uses the default reward receiver
-                     for the caller
+    @notice Get the timestamp of the last checkpoint
     """
-    if _receiver != empty(address):
-        assert _addr == msg.sender  # dev: cannot redirect when claiming for another user
-    self._checkpoint_rewards(_addr, self.totalSupply, True, _receiver)
-
-
-@external
-def add_reward(_reward_token: address, _distributor: address):
-    """
-    @notice Set the active reward contract
-    """
-    assert msg.sender == self.manager or msg.sender == FACTORY.owner()
-    assert _reward_token != FACTORY.crv().address
-
-    reward_count: uint256 = self.reward_count
-    assert reward_count < MAX_REWARDS
-    assert self.reward_data[_reward_token].distributor == empty(address)
-
-    self.reward_data[_reward_token].distributor = _distributor
-    self.reward_tokens[reward_count] = _reward_token
-    self.reward_count = reward_count + 1
-
-
-@external
-def set_reward_distributor(_reward_token: address, _distributor: address):
-    current_distributor: address = self.reward_data[_reward_token].distributor
-
-    assert msg.sender == current_distributor or msg.sender == self.manager or msg.sender == FACTORY.owner()
-    assert current_distributor != empty(address)
-    assert _distributor != empty(address)
-
-    self.reward_data[_reward_token].distributor = _distributor
-
-
-@external
-@nonreentrant("lock")
-def deposit_reward_token(_reward_token: address, _amount: uint256, _epoch: uint256 = WEEK):
-    assert msg.sender == self.reward_data[_reward_token].distributor
-
-    self._checkpoint_rewards(empty(address), self.totalSupply, False, empty(address))
-
-    # transferFrom reward token and use transferred amount henceforth:
-    amount_received: uint256 = ERC20(_reward_token).balanceOf(self)
-    assert ERC20(_reward_token).transferFrom(
-        msg.sender,
-        self,
-        _amount,
-        default_return_value=True
-    )
-    amount_received = ERC20(_reward_token).balanceOf(self) - amount_received
-
-    period_finish: uint256 = self.reward_data[_reward_token].period_finish
-    assert amount_received > _epoch  # dev: rate will tend to zero!
-
-    unused: uint256 = 0
-    if block.timestamp >= period_finish:
-        self.reward_data[_reward_token].rate = amount_received / _epoch
-        unused = amount_received % _epoch
-    else:
-        remaining: uint256 = period_finish - block.timestamp
-        leftover: uint256 = remaining * self.reward_data[_reward_token].rate
-        self.reward_data[_reward_token].rate = (amount_received + leftover) / _epoch
-        unused = (amount_received + leftover) % _epoch
-
-    # Return tokens unused due to rate calculation error
-    self.claim_data[self.reward_data[_reward_token].distributor][_reward_token] += shift(unused, 128)
-
-    self.reward_data[_reward_token].last_update = block.timestamp
-    self.reward_data[_reward_token].period_finish = block.timestamp + _epoch
-
-
-@external
-def set_manager(_manager: address):
-    assert msg.sender == FACTORY.owner()
-
-    self.manager = _manager
-
-
-@external
-def set_root_gauge(_root: address):
-    """
-    @notice Set Root contract in case something went wrong (e.g. between implementation updates)
-    @param _root Root gauge to set
-    """
-    assert msg.sender == FACTORY.owner()
-    assert _root != empty(address)
-
-    self.root_gauge = _root
-
-
-@external
-def update_voting_escrow():
-    """
-    @notice Update the voting escrow contract in storage
-    """
-    self.voting_escrow = FACTORY.voting_escrow()
-
-
-@external
-def set_killed(_is_killed: bool):
-    """
-    @notice Set the kill status of the gauge
-    @param _is_killed Kill status to put the gauge into
-    """
-    assert msg.sender == FACTORY.owner()
-
-    self.is_killed = _is_killed
+    return self.period_timestamp[self.period]
 
 
 @view
 @external
 def decimals() -> uint256:
     """
-    @notice Returns the number of decimals the token uses
+    @notice Get the number of decimals for this token
+    @dev Implemented as a view method to reduce gas costs
+    @return uint256 decimal places
     """
     return 18
 
 
 @view
 @external
-def integrate_checkpoint() -> uint256:
-    return self.period_timestamp[self.period]
+def version() -> String[8]:
+    """
+    @notice Get the version of this gauge contract
+    """
+    return VERSION
 
 
 @view
 @external
 def factory() -> Factory:
     return FACTORY
-
-
-@view
-@external
-def VERSION() -> String[8]:
-    return version
-
-
-@external
-def initialize(_lp_token: address, _root: address, _manager: address):
-    assert self.lp_token == empty(address)  # dev: already initialzed
-
-    self.lp_token = _lp_token
-    self.root_gauge = _root
-    self.manager = _manager
-
-    self.voting_escrow = Factory(msg.sender).voting_escrow()
-
-    symbol: String[26] = ERC20Extended(_lp_token).symbol()
-    name: String[64] = concat("Curve.fi ", symbol, " Gauge Deposit")
-
-    self.name = name
-    self.symbol = concat(symbol, "-gauge")
-
-    self.period_timestamp[0] = block.timestamp
-    self.DOMAIN_SEPARATOR = keccak256(
-        _abi_encode(
-            DOMAIN_TYPE_HASH,
-            keccak256(name),
-            keccak256(version),
-            chain.id,
-            self
-        )
-    )

--- a/contracts/implementations/ChildGauge.vy
+++ b/contracts/implementations/ChildGauge.vy
@@ -616,6 +616,7 @@ def add_reward(_reward_token: ERC20, _distributor: address, _precision: uint256=
     @return ID of added reward
     """
     assert msg.sender == self.manager or msg.sender == FACTORY.owner()
+    assert _reward_token != FACTORY.crv()
 
     precision: uint256 = _precision
     if precision == 0:

--- a/contracts/implementations/ChildGauge.vy
+++ b/contracts/implementations/ChildGauge.vy
@@ -232,7 +232,8 @@ def _checkpoint_rewards(_user: address, _total_supply: uint256, _claim: bool, _r
                 self.reward_data[token].integral = integral
             else:
                 # Return not distributed back
-                self.claim_data[self.reward_data[token].distributor][token] += shift(duration * self.reward_data[token].rate, 128)
+                self.claim_data[self.reward_data[token].distributor][token] +=\
+                    shift(duration * self.reward_data[token].rate, 128)
 
         if _user != empty(address):
             integral_for: uint256 = self.reward_integral_for[token][_user]

--- a/contracts/implementations/ChildGauge.vy
+++ b/contracts/implementations/ChildGauge.vy
@@ -795,7 +795,7 @@ def rate_per_lp_token(_reward_id: uint256, _with_precision: bool=False) -> uint2
     precision: uint256 = 0
     rate, precision = self._rate(_reward_id)
 
-    rate = rate * 10 ** 18 / self.totalSupply
+    rate = rate * 10 ** 18 / max(self.totalSupply, 10 ** 18)
     if _with_precision:
         return rate
     return rate / precision

--- a/contracts/implementations/ChildGauge.vy
+++ b/contracts/implementations/ChildGauge.vy
@@ -703,12 +703,12 @@ def recover_remaining_reward(_reward_id: uint256, _receiver: address=msg.sender)
     """
     self._checkpoint_rewards(empty(address), self.totalSupply, False, empty(address))
 
-    reward_data: RewardData = self.reward_data[_reward_id]
-    assert msg.sender == reward_data.distributor
-    assert reward_data.remaining_time == 0, "Distribution in progress"
+    assert msg.sender == self.reward_data[_reward_id].distributor
+    assert self.reward_data[_reward_id].remaining_time == 0, "Distribution in progress"
 
+    remaining_amount: uint256 = self.reward_data[_reward_id].remaining_amount
     self.reward_data[_reward_id].remaining_amount = 0
-    assert reward_data.token.transfer(_receiver, reward_data.remaining_amount, default_return_value=True)
+    assert self.reward_data[_reward_id].token.transfer(_receiver, remaining_amount, default_return_value=True)
 
 
 @external
@@ -739,9 +739,8 @@ def lock_reward(_reward_id: uint256):
     """
     self._checkpoint_rewards(empty(address), self.totalSupply, False, empty(address))
 
-    reward_data: RewardData = self.reward_data[_reward_id]
-    assert msg.sender == reward_data.distributor
-    assert reward_data.remaining_time > 0, "Nothing to lock"
+    assert msg.sender == self.reward_data[_reward_id].distributor
+    assert self.reward_data[_reward_id].remaining_time > 0, "Nothing to lock"
 
     self.reward_data[_reward_id].locked = True
 

--- a/scripts/calculate_proxy.py
+++ b/scripts/calculate_proxy.py
@@ -41,12 +41,12 @@ def create2_address_of(_addr, _salt, _initcode):
     return to_address(keccak(prefix + addr + salt + keccak(initcode))[12:])
 
 
-def main(_chain_id: str, _deployer: str, _salt: str):
+def main(_chain_id: str, _salt: str):
     factory = RootGaugeFactory.at("0xabC000d88f23Bb45525E447528DBF656A9D55bf5")
     implementation_addr = factory.get_implementation()
 
     init_code = vyper_proxy_init_code(implementation_addr)
     salt = keccak(
-        encode_single("(uint256,address,bytes32)", [int(_chain_id), _deployer, HexBytes(_salt)])
+        encode_single("(uint256,bytes32)", [int(_chain_id), HexBytes(_salt)])
     )
     print(create2_address_of(factory.address, salt, init_code))

--- a/tests/child_gauge/test_rewards.py
+++ b/tests/child_gauge/test_rewards.py
@@ -1,4 +1,6 @@
 import brownie
+from brownie.test import given, strategy
+from hypothesis import settings
 
 WEEK = 86400 * 7
 
@@ -14,55 +16,29 @@ def test_only_manager_or_factory_owner(alice, bob, charlie, chain, child_gauge, 
         child_gauge.add_reward(reward_token, charlie, {"from": charlie})
 
 
-def test_add_reward(alice, charlie, child_gauge, reward_token, reward_token_8):
-    reward_id = child_gauge.add_reward(reward_token, charlie, {"from": alice}).return_value
+def test_add_reward(alice, charlie, child_gauge, reward_token):
+    child_gauge.add_reward(reward_token, charlie, {"from": alice})
     assert child_gauge.reward_count() == 1
-    assert child_gauge.reward_data(reward_id) == (
-        reward_token,  # token: ERC20
+    assert child_gauge.reward_data(reward_token) == (
         charlie,  # distributor: address
         0,  # period_finish: uint256
         0,  # rate: uint256
         0,  # last_update: uint256
         0,  # integral: uint256
-        1,  # precision: uint256
-    )
-
-    reward_id = child_gauge.add_reward(reward_token_8, charlie, {"from": alice}).return_value
-    assert child_gauge.reward_count() == 2
-    assert child_gauge.reward_data(reward_id) == (
-        reward_token_8,  # token: ERC20
-        charlie,  # distributor: address
-        0,  # period_finish: uint256
-        0,  # rate: uint256
-        0,  # last_update: uint256
-        0,  # integral: uint256
-        10 ** 10,  # precision: uint256
-    )
-
-    reward_id = child_gauge.add_reward(reward_token_8, charlie, 10 ** 4, {"from": alice}).return_value
-    assert child_gauge.reward_count() == 3
-    assert child_gauge.reward_data(reward_id) == (
-        reward_token_8,  # token: ERC20
-        charlie,  # distributor: address
-        0,  # period_finish: uint256
-        0,  # rate: uint256
-        0,  # last_update: uint256
-        0,  # integral: uint256
-        10 ** 4,  # precision: uint256
     )
 
 
 def test_set_reward_distributor_admin_only(accounts, chain, reward_token, child_gauge):
     child_gauge.set_manager(accounts[1], {"from": accounts[0]})
-    reward_id = child_gauge.add_reward(reward_token, accounts[2], {"from": accounts[0]}).return_value
+    child_gauge.add_reward(reward_token, accounts[2], {"from": accounts[0]})
 
     for i in range(3):
-        child_gauge.set_reward_distributor(reward_id, accounts[-1], {"from": accounts[i]})
-        assert child_gauge.reward_data(reward_id)["distributor"] == accounts[-1]
+        child_gauge.set_reward_distributor(reward_token, accounts[-1], {"from": accounts[i]})
+        assert child_gauge.reward_data(reward_token)["distributor"] == accounts[-1]
         chain.undo()
 
     with brownie.reverts():
-        child_gauge.set_reward_distributor(reward_id, accounts[-1], {"from": accounts[3]})
+        child_gauge.set_reward_distributor(reward_token, accounts[-1], {"from": accounts[3]})
 
 
 def test_deposit_reward_token(alice, child_gauge, reward_token):
@@ -70,34 +46,92 @@ def test_deposit_reward_token(alice, child_gauge, reward_token):
     reward_token._mint_for_testing(alice, amount, {"from": alice})
     reward_token.approve(child_gauge, 2**256 - 1, {"from": alice})
 
-    reward_id = child_gauge.add_reward(reward_token, alice, {"from": alice}).return_value
-    tx = child_gauge.deposit_reward_token(reward_id, amount, {"from": alice})
+    child_gauge.add_reward(reward_token, alice, {"from": alice})
+    tx = child_gauge.deposit_reward_token(reward_token, amount, {"from": alice})
 
     reward_data = [
-        reward_token,  # token: ERC20
         alice,  # distributor: address
         tx.timestamp + WEEK,  # period_finish: uint256
         amount // WEEK,  # rate: uint256
         tx.timestamp,  # last_update: uint256
         0,  # integral: uint256
-        1,  # precision: uint256
     ]
-    assert child_gauge.reward_data(reward_id) == reward_data
+    assert child_gauge.reward_data(reward_token) == reward_data
 
     # Increase rate
     amount += 10 ** 18
     reward_token._mint_for_testing(alice, 10 ** 18, {"from": alice})
-    tx = child_gauge.deposit_reward_token(reward_id, 10 ** 18, {"from": alice})
+    tx = child_gauge.deposit_reward_token(reward_token, 10 ** 18, {"from": alice})
 
-    reward_data = reward_data[:2] + [
+    reward_data = [
+        alice,  # distributor: address
         tx.timestamp + WEEK,  # period_finish: uint256
-        amount // WEEK,  # rate: uint256, totalSupply == 0 not counted hence fail
+        amount // WEEK,  # rate: uint256
         tx.timestamp,  # last_update: uint256
-    ] + reward_data[5:]
-    assert child_gauge.reward_data(reward_id) == reward_data
+        0,  # integral: uint256
+    ]
+    assert child_gauge.reward_data(reward_token) == reward_data
 
     # Increase period
-    # _new_duration
-    # _new_period_finish
-    # Week period rekt allowed
-    # longer period rekt forbidden
+    tx = child_gauge.deposit_reward_token(reward_token, 0, 2 * WEEK, {"from": alice})
+
+    reward_data = [
+        alice,  # distributor: address
+        tx.timestamp + 2 * WEEK,  # period_finish: uint256
+        amount // (2 * WEEK),  # rate: uint256
+        tx.timestamp,  # last_update: uint256
+        0,  # integral: uint256
+    ]
+    assert child_gauge.reward_data(reward_token) == reward_data
+
+    # Decrease period
+    tx = child_gauge.deposit_reward_token(reward_token, 0, WEEK // 2, {"from": alice})
+
+    reward_data = [
+        alice,  # distributor: address
+        tx.timestamp + WEEK // 2,  # period_finish: uint256
+        amount // (WEEK // 2),  # rate: uint256
+        tx.timestamp,  # last_update: uint256
+        0,  # integral: uint256
+    ]
+    assert child_gauge.reward_data(reward_token) == reward_data
+
+
+def test_deposit_reward_token(alice, child_gauge, reward_token):
+    child_gauge.add_reward(reward_token, alice, {"from": alice})
+    with brownie.reverts():
+        child_gauge.deposit_reward_token(reward_token, 0, WEEK * 3 // 7 - 1, {"from": alice})
+    with brownie.reverts():
+        child_gauge.deposit_reward_token(reward_token, 0, WEEK * 4 * 12 + 1, {"from": alice})
+
+
+@given(
+    lp_amount=strategy('uint256', min_value=1, max_value=10 ** 9),
+    delta=strategy('uint256', min_value=1, max_value=10 ** 6),
+)
+@settings(max_examples=20)
+def test_reward_remaining(alice, bob, charlie, child_gauge, reward_token, lp_token, chain, lp_amount, delta):
+    lp_token._mint_for_testing(alice, lp_amount * 10 ** 18, {"from": alice})
+    lp_token.approve(child_gauge, lp_amount * 10 ** 18, {"from": alice})
+    child_gauge.deposit(lp_amount * 10 ** 18, {"from": alice})
+
+    reward_amount = lp_amount + delta
+    reward_period = WEEK * 3 // 7  # minimum period
+    child_gauge.add_reward(reward_token, bob, {"from": alice})
+    reward_token._mint_for_testing(bob, reward_amount, {"from": bob})
+    reward_token.approve(child_gauge, reward_amount, {"from": bob})
+    child_gauge.deposit_reward_token(reward_token, reward_amount, reward_period, {"from": bob})
+
+    checkpoints = 10
+    for _ in range(checkpoints):
+        chain.sleep(reward_period // checkpoints)
+        child_gauge.claim_rewards({"from": alice})
+
+    received = reward_token.balanceOf(alice)
+    assert received == reward_amount - reward_amount % lp_amount
+
+    remaining = child_gauge.reward_remaining(reward_token)
+    assert remaining + received == reward_amount
+
+    child_gauge.recover_remaining(reward_token, {"from": charlie})
+    assert reward_token.balanceOf(bob) == remaining

--- a/tests/child_gauge/test_rewards.py
+++ b/tests/child_gauge/test_rewards.py
@@ -14,42 +14,90 @@ def test_only_manager_or_factory_owner(alice, bob, charlie, chain, child_gauge, 
         child_gauge.add_reward(reward_token, charlie, {"from": charlie})
 
 
-def test_reward_data_updated(alice, charlie, child_gauge, reward_token):
-
-    child_gauge.add_reward(reward_token, charlie, {"from": alice})
-    expected_data = (charlie, 0, 0, 0, 0)
-
+def test_add_reward(alice, charlie, child_gauge, reward_token, reward_token_8):
+    reward_id = child_gauge.add_reward(reward_token, charlie, {"from": alice}).return_value
     assert child_gauge.reward_count() == 1
-    assert child_gauge.reward_tokens(0) == reward_token
-    assert child_gauge.reward_data(reward_token) == expected_data
+    assert child_gauge.reward_data(reward_id) == (
+        reward_token,  # token: ERC20
+        charlie,  # distributor: address
+        0,  # period_finish: uint256
+        0,  # rate: uint256
+        0,  # last_update: uint256
+        0,  # integral: uint256
+        1,  # precision: uint256
+    )
 
+    reward_id = child_gauge.add_reward(reward_token_8, charlie, {"from": alice}).return_value
+    assert child_gauge.reward_count() == 2
+    assert child_gauge.reward_data(reward_id) == (
+        reward_token_8,  # token: ERC20
+        charlie,  # distributor: address
+        0,  # period_finish: uint256
+        0,  # rate: uint256
+        0,  # last_update: uint256
+        0,  # integral: uint256
+        10 ** 10,  # precision: uint256
+    )
 
-def test_reverts_for_double_adding(alice, child_gauge, reward_token):
-    child_gauge.add_reward(reward_token, alice, {"from": alice})
-
-    with brownie.reverts():
-        child_gauge.add_reward(reward_token, alice, {"from": alice})
+    reward_id = child_gauge.add_reward(reward_token_8, charlie, 10 ** 4, {"from": alice}).return_value
+    assert child_gauge.reward_count() == 3
+    assert child_gauge.reward_data(reward_id) == (
+        reward_token_8,  # token: ERC20
+        charlie,  # distributor: address
+        0,  # period_finish: uint256
+        0,  # rate: uint256
+        0,  # last_update: uint256
+        0,  # integral: uint256
+        10 ** 4,  # precision: uint256
+    )
 
 
 def test_set_reward_distributor_admin_only(accounts, chain, reward_token, child_gauge):
     child_gauge.set_manager(accounts[1], {"from": accounts[0]})
-    child_gauge.add_reward(reward_token, accounts[2], {"from": accounts[0]})
+    reward_id = child_gauge.add_reward(reward_token, accounts[2], {"from": accounts[0]}).return_value
 
     for i in range(3):
-        child_gauge.set_reward_distributor(reward_token, accounts[-1], {"from": accounts[i]})
-        assert child_gauge.reward_data(reward_token)["distributor"] == accounts[-1]
+        child_gauge.set_reward_distributor(reward_id, accounts[-1], {"from": accounts[i]})
+        assert child_gauge.reward_data(reward_id)["distributor"] == accounts[-1]
         chain.undo()
 
     with brownie.reverts():
-        child_gauge.set_reward_distributor(reward_token, accounts[-1], {"from": accounts[3]})
+        child_gauge.set_reward_distributor(reward_id, accounts[-1], {"from": accounts[3]})
 
 
 def test_deposit_reward_token(alice, child_gauge, reward_token):
-    reward_token._mint_for_testing(alice, 10**26, {"from": alice})
+    amount = 10 ** 26
+    reward_token._mint_for_testing(alice, amount, {"from": alice})
     reward_token.approve(child_gauge, 2**256 - 1, {"from": alice})
 
-    child_gauge.add_reward(reward_token, alice, {"from": alice})
-    tx = child_gauge.deposit_reward_token(reward_token, 10**26, {"from": alice})
+    reward_id = child_gauge.add_reward(reward_token, alice, {"from": alice}).return_value
+    tx = child_gauge.deposit_reward_token(reward_id, amount, {"from": alice})
 
-    expected = (alice, tx.timestamp + WEEK, 10**26 // WEEK, tx.timestamp, 0)
-    assert child_gauge.reward_data(reward_token) == expected
+    reward_data = [
+        reward_token,  # token: ERC20
+        alice,  # distributor: address
+        tx.timestamp + WEEK,  # period_finish: uint256
+        amount // WEEK,  # rate: uint256
+        tx.timestamp,  # last_update: uint256
+        0,  # integral: uint256
+        1,  # precision: uint256
+    ]
+    assert child_gauge.reward_data(reward_id) == reward_data
+
+    # Increase rate
+    amount += 10 ** 18
+    reward_token._mint_for_testing(alice, 10 ** 18, {"from": alice})
+    tx = child_gauge.deposit_reward_token(reward_id, 10 ** 18, {"from": alice})
+
+    reward_data = reward_data[:2] + [
+        tx.timestamp + WEEK,  # period_finish: uint256
+        amount // WEEK,  # rate: uint256, totalSupply == 0 not counted hence fail
+        tx.timestamp,  # last_update: uint256
+    ] + reward_data[5:]
+    assert child_gauge.reward_data(reward_id) == reward_data
+
+    # Increase period
+    # _new_duration
+    # _new_period_finish
+    # Week period rekt allowed
+    # longer period rekt forbidden

--- a/tests/child_gauge_factory/test_deploy_child_gauge.py
+++ b/tests/child_gauge_factory/test_deploy_child_gauge.py
@@ -16,7 +16,7 @@ def test_deploy_child_gauge(
 ):
     proxy_init_code = vyper_proxy_init_code(child_gauge_impl.address)
     salt = encode(
-        ["(uint256,address,bytes32)"], [(chain.id, alice.address, (0).to_bytes(32, "big"))]
+        ["(uint256,bytes32)"], [(chain.id, (0).to_bytes(32, "big"))]
     )
     expected = create2_address_of(child_gauge_factory.address, web3.keccak(salt), proxy_init_code)
 

--- a/tests/fixtures/deployments.py
+++ b/tests/fixtures/deployments.py
@@ -40,11 +40,6 @@ def reward_token(alice):
 
 
 @pytest.fixture(scope="module")
-def reward_token_8(alice):
-    return ERC20("Dummy Reward Token", "dRT", 8, deployer=alice)
-
-
-@pytest.fixture(scope="module")
 def unauthorised_token(alice):
     """This is for testing unauthorised token"""
     return ERC20("Dummy Unauthorised Reward Token", "dURT", 18, deployer=alice)

--- a/tests/fixtures/deployments.py
+++ b/tests/fixtures/deployments.py
@@ -40,6 +40,11 @@ def reward_token(alice):
 
 
 @pytest.fixture(scope="module")
+def reward_token_8(alice):
+    return ERC20("Dummy Reward Token", "dRT", 8, deployer=alice)
+
+
+@pytest.fixture(scope="module")
 def unauthorised_token(alice):
     """This is for testing unauthorised token"""
     return ERC20("Dummy Unauthorised Reward Token", "dURT", 18, deployer=alice)

--- a/tests/root_gauge_factory/test_gauge_addresses.py
+++ b/tests/root_gauge_factory/test_gauge_addresses.py
@@ -1,24 +1,7 @@
 from brownie import Contract, web3
-from brownie.convert import to_address
 from eth_abi import encode
-from hexbytes import HexBytes
 
 SALT = b"5A170000000000000000000000000000"
-
-
-def salt(chain_id, sender):
-    return web3.keccak(encode(["(uint256,address,bytes32)"], [(chain_id, sender, SALT)]))
-
-
-def zksync_create2_address_of(_addr, _salt, _initcode):
-    prefix = web3.keccak(text="zksyncCreate2")
-    addr = HexBytes(_addr)
-    addr = HexBytes(0) * 12 + addr + HexBytes(0) * (20 - len(addr))
-    salt = HexBytes(_salt)
-    initcode = HexBytes(_initcode)
-    return to_address(
-        web3.keccak(prefix + addr + salt + web3.keccak(initcode) + web3.keccak(b""))[12:]
-    )
 
 
 def test_gauge_address(
@@ -57,12 +40,11 @@ def test_gauge_address_chain_id(
     RootGauge,
     vyper_proxy_init_code,
     create2_address_of,
-    web3,
 ):
     chain_id = chain.id + 1
     proxy_init_code = vyper_proxy_init_code(child_gauge_impl.address)
     expected = create2_address_of(
-        child_gauge_factory.address, salt(chain_id, alice.address), proxy_init_code
+        child_gauge_factory.address, web3.keccak(encode(["(uint256,bytes32)"], [(chain_id, SALT)])), proxy_init_code
     )
     bridger = MockBridger.deploy({"from": alice})
     root_gauge_factory.set_child(

--- a/tests/root_gauge_factory/test_root_gauge_deploy.py
+++ b/tests/root_gauge_factory/test_root_gauge_deploy.py
@@ -15,7 +15,7 @@ def test_deploy_root_gauge(
 ):
     proxy_init_code = vyper_proxy_init_code(root_gauge_impl.address)
     salt = encode(
-        ["(uint256,address,bytes32)"], [(chain.id, alice.address, (0).to_bytes(32, "big"))]
+        ["(uint256,bytes32)"], [(chain.id, (0).to_bytes(32, "big"))]
     )
     expected = create2_address_of(root_gauge_factory.address, web3.keccak(salt), proxy_init_code)
 


### PR DESCRIPTION
## About
Making ready for handy use in curve-lite and update among all L2s.

### Problems
- CRV set later (already done in previous PR)
- Currently reward period is strictly one WEEK, what is not convenient. Making it arbitrary
- Bad precision for not 18 decimal tokens
- If `totalSupply == 0` and rewards were allocated, funds for that period will stuck in contract forever
- CRV as a reward can not be distinguished from CRV emissions

## What I did
- Bumped latest LiquidityGaugeV6, so they are visually similar and have all comments and docs.
- Added better calculation precision along with some tests